### PR TITLE
Chore: Node version pinning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/krypton

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },
+  "engines": {
+    "npm": ">=10.0.0",
+    "node": ">=22.0.0"
+  },
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
- Added node and npm engines to `package.json`
- Added .npmrc to enforce engines values
- Added .nvmrc to make it easy to use a correct version of Node
- Updated version of Node used in the GitHub action to match the engines value