### PR TITLE
chore(config): Fixed warnings from Rollup and TypeScript

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -13,6 +13,7 @@ const config: RollupOptions = {
     lezer(),
     typescript({
       tsconfig: "./tsconfig.lib.json",
+      outputToFilesystem: true,
     }),
   ],
 };

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "src",
     "outDir": "dist",
     "target": "es2020",
@@ -9,7 +8,7 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": true
   },
   "include": ["src/*.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,13 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "noEmit": true,
-    "outDir": "dist-node",
     "target": "esnext",
     "lib": ["esnext"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "preserve",
+    "moduleResolution": "bundler"
   },
   "include": ["eslint.config.ts", "rollup.config.ts", "test/*.ts"]
 }


### PR DESCRIPTION
TypeScript was complaining about a type error in `rollup.config.ts` and Rollup was complaining about a configuration variable not being explicitly set. These have now been resolved.