### PR TITLE
fix(lint-actions): Define pace name lint action now uses correct syntax

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -44,7 +44,7 @@ export function undefinedPaceNameActions(
     name: "Define pace name",
     apply(view: EditorView) {
       view.dispatch({
-        changes: { from: 0, to: 0, insert: `Pace ${undefinedName} = _%\n` },
+        changes: { from: 0, to: 0, insert: `pace ${undefinedName} = _%\n` },
       });
     },
   });


### PR DESCRIPTION
At some point in the past, the pace keyword was changed to use a lowercase 'p', however the "Define pace name" lint action, which generates a pace name definition statement, was never updated to match. This highlights a flaw in the projects architecture which seems far too troublesome to solve.