### PR TITLE
feat(author-definition): Created new AuthorDefinition statement

### DIFF
--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -4,6 +4,7 @@ export const enum Statements {
   MESSAGE,
   PACE_DEFINITION,
   CONSTANT_DEFINITION,
+  AUTHOR_DEFINITION,
 }
 
 export const enum InstructionModifiers {
@@ -24,7 +25,18 @@ export interface ConstantDefinition {
   value: string;
 }
 
-export type Statement = Instruction | PaceDefinition | ConstantDefinition;
+export interface AuthorDefintion {
+  statement: Statements.AUTHOR_DEFINITION;
+  firstName: string;
+  lastName: string;
+  emailAddress?: string | undefined;
+}
+
+export type Statement =
+  | Instruction
+  | PaceDefinition
+  | ConstantDefinition
+  | AuthorDefintion;
 
 export interface EquipmentSpecification {
   modifier: InstructionModifiers.EQUIPMENT_SPECIFICATION;

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -1,5 +1,6 @@
 import { TreeCursor } from "@lezer/common";
 import {
+  AuthorDefintion,
   BlockInstruction,
   ConstantDefinition,
   Instruction,
@@ -495,6 +496,47 @@ function visitConstantDefinition(
 }
 
 /**
+ * Create an AST node for a `AuthorDefinition` CST node.
+ *
+ * Precondition: `cursor` points to an `AuthorDefinition` node.
+ *
+ * Postcondition: `cursor` will point to the same node it pointed to when
+ * passed to this function.
+ *
+ * @param cursor - A reference to a Lezer syntax tree node.
+ * @param state - The state of the CodeMirror editor.
+ *
+ * @returns An `AuthorDefinition` AST node.
+ */
+function visitAuthorDefinition(
+  cursor: TreeCursor,
+  state: EditorState,
+): AuthorDefintion {
+  // Move into AuthorDefinition's first child, the first name
+  cursor.firstChild();
+  const firstName = state.sliceDoc(cursor.from, cursor.to);
+
+  // Move into last name
+  cursor.nextSibling();
+  const lastName = state.sliceDoc(cursor.from, cursor.to);
+
+  let emailAddress: string | undefined;
+  // Move into email address, if it exists
+  if (cursor.nextSibling()) {
+    emailAddress = state.sliceDoc(cursor.from, cursor.to);
+  }
+
+  // Move back up to the AuthorDefinition
+  cursor.parent();
+  return {
+    statement: Statements.AUTHOR_DEFINITION,
+    firstName,
+    lastName,
+    emailAddress,
+  };
+}
+
+/**
  * Create an AST for the current program in `state`.
  *
  * Precondition: `cursor` points to the topmost node (`SwimProgramme`).
@@ -532,6 +574,9 @@ export default function buildAst(
           break;
         case "ConstantDefinition":
           node = visitConstantDefinition(cursor, state);
+          break;
+        case "AuthorDefinition":
+          node = visitAuthorDefinition(cursor, state);
           break;
         default:
           break;

--- a/src/enumerations.ts
+++ b/src/enumerations.ts
@@ -71,7 +71,6 @@ export const equipmentNames = [
  */
 export const constantNames = [
   "Title",
-  "Author",
   "Description",
   "Date",
   "PoolLength",

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -1,5 +1,6 @@
 import { create } from "xmlbuilder2";
 import {
+  AuthorDefintion,
   ConstantDefinition,
   Instruction,
   InstructionModifier,
@@ -236,6 +237,27 @@ function writeConstantDefinition(
 }
 
 /**
+ * Write an AST AuthorDefintion node into the XML document.
+ *
+ * @param xmlParent - The parent XML node to write the author definition inside
+ *    of.
+ * @param instruction - The AST author definition node to write as XML.
+ */
+function writeAuthorDefinition(
+  xmlParent: XMLBuilder,
+  definition: AuthorDefintion,
+): void {
+  const authorNode = xmlParent.ele("author");
+
+  authorNode.ele("firstName").txt(definition.firstName);
+  authorNode.ele("lastName").txt(definition.lastName);
+
+  if (definition.emailAddress) {
+    authorNode.ele("email").txt(definition.emailAddress);
+  }
+}
+
+/**
  * Given a complete AST for a SwimDSL document, generate a valid swiML XML
  * document describing the same programme.
  *
@@ -270,6 +292,10 @@ export default function emitXml(programme: Programme): string {
 
       case Statements.CONSTANT_DEFINITION:
         writeConstantDefinition(doc, statement);
+        break;
+
+      case Statements.AUTHOR_DEFINITION:
+        writeAuthorDefinition(doc, statement);
         break;
     }
   }

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -198,10 +198,6 @@ function writeConstantDefinition(
       xmlParent.ele("title").txt(definition.value);
       break;
 
-    case "Author":
-      xmlParent.ele("author").ele("firstName").txt(definition.value);
-      break;
-
     case "Description":
       xmlParent.ele("programDescription").txt(definition.value);
       break;

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -18,6 +18,10 @@ Boolean {
   identifier
 }
 
+AuthorDefinition {
+    authorKeyword string string string?
+}
+
 PaceDefinition {
     paceKeyword PaceDefinitionName "=" Pace
 }
@@ -41,6 +45,7 @@ PaceAlias { identifier }  // a named pace, e.g., easy or hard
 statement {
     instruction
     | ConstantDefinition
+    | AuthorDefinition
     | PaceDefinition
 }
 
@@ -101,6 +106,7 @@ messageSpecification {
 
 @tokens {
     setKeyword            { "set" }
+    authorKeyword         { "author" }
     paceKeyword           { "pace" }
     restKeyword           { "rest" }
     onKeyword             { "on" }
@@ -116,6 +122,7 @@ messageSpecification {
     @precedence { repititionOperator, identifier }
     @precedence { paceKeyword, identifier }
     @precedence { setKeyword, identifier }
+    @precedence { authorKeyword, identifier }
     @precedence { onKeyword, identifier }
     @precedence { space, Message }
     @precedence { Comment, Message }


### PR DESCRIPTION
In the name of having swimDSL support the full swiML XML schema, I have introduced a new AuthorDefinition statement. This improves over the now removed Author constant as it allows for specifying author last name and email address, which was not previously possible.

<img width="2408" height="877" alt="Screenshot from 2026-04-19 08-10-51" src="https://github.com/user-attachments/assets/032954ca-7776-4a9f-9d6c-aa0dcd6794ba" />

Closes #30