### PR TITLE
refactor: Changed type signature of levenshtien util function

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,6 +3,7 @@ import { EditorView } from "@codemirror/view";
 import { SyntaxNodeRef } from "@lezer/common";
 
 import { closestLevenshtienDistance } from "./utils";
+import type { NonEmptyArray, ReadonlyNonEmptyArray } from "./types";
 
 /**
  * The maximum distance between a typed identifier, and the closest valid
@@ -24,20 +25,22 @@ export function undefinedPaceNameActions(
   undefinedName: string,
   definedNames: Set<string>,
 ): Action[] {
-  const [closestName, distance] = closestLevenshtienDistance(
-    undefinedName,
-    Array.from(definedNames),
-  );
-
   const actions: Action[] = [];
 
-  if (distance <= MAX_LEVENSHTIEN_DISTANCE) {
-    actions.push({
-      name: `Did you mean '${closestName}'?`,
-      apply(view: EditorView, from: number, to: number) {
-        view.dispatch({ changes: { from, to, insert: closestName } });
-      },
-    });
+  if (definedNames.size > 0) {
+    const [closestName, distance] = closestLevenshtienDistance(
+      undefinedName,
+      Array.from(definedNames) as NonEmptyArray<string>,
+    );
+
+    if (distance <= MAX_LEVENSHTIEN_DISTANCE) {
+      actions.push({
+        name: `Did you mean '${closestName}'?`,
+        apply(view: EditorView, from: number, to: number) {
+          view.dispatch({ changes: { from, to, insert: closestName } });
+        },
+      });
+    }
   }
 
   actions.push({
@@ -88,7 +91,7 @@ export function duplicatePaceNameDefinitionActions(
  */
 export function invalidNodeValueActions(
   invalidValue: string,
-  validValues: string[],
+  validValues: ReadonlyNonEmptyArray<string>,
 ): Action[] {
   const [closestValue, distance] = closestLevenshtienDistance(
     invalidValue,

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -6,6 +6,7 @@ import {
   duplicatePaceNameDefinitionActions,
   invalidNodeValueActions,
 } from "./actions";
+import type { ReadonlyNonEmptyArray } from "./types";
 
 /**
  * Provides the user with an error message and resolution actions when they
@@ -151,7 +152,7 @@ export function invalidNodeValueDiagnostic(
   node: SyntaxNodeRef,
   nodeValue: string,
   nodeName: string,
-  validValues: string[],
+  validValues: ReadonlyNonEmptyArray<string>,
 ): Diagnostic {
   return {
     from: node.from,

--- a/src/enumerations.ts
+++ b/src/enumerations.ts
@@ -1,7 +1,7 @@
 /**
  * The list of all strings considered valid in place of a stroke name.
  */
-export const strokeNames: string[] = [
+export const strokeNames = [
   "Freestyle",
   "Free",
   "Fr",
@@ -46,17 +46,17 @@ export const strokeNames: string[] = [
   "NotButterfly",
   "NotFly",
   "NotFl",
-];
+] as const;
 
 /**
  * The list of all strings considered valid in place of a stroke type.
  */
-export const strokeTypes: string[] = ["Pull", "Kick", "Drill"];
+export const strokeTypes = ["Pull", "Kick", "Drill"] as const;
 
 /**
  * The list of all strings considered valid in place of an equipment name.
  */
-export const equipmentNames: string[] = [
+export const equipmentNames = [
   "Board",
   "Pads",
   "PullBuoy",
@@ -64,12 +64,12 @@ export const equipmentNames: string[] = [
   "Snorkel",
   "Chute",
   "StretchCord",
-];
+] as const;
 
 /**
  * The list of all strings considered valid in place of a constant name.
  */
-export const constantNames: string[] = [
+export const constantNames = [
   "Title",
   "Author",
   "Description",
@@ -80,9 +80,9 @@ export const constantNames: string[] = [
   "NumeralSystem",
   "HideIntro",
   "LayoutWidth",
-];
+] as const;
 
 /**
  * The list of all strings considered valid in place of a boolean.
  */
-export const booleans: string[] = ["True", "False"];
+export const booleans = ["True", "False"] as const;

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -20,6 +20,7 @@ import {
   strokeNames,
   strokeTypes,
 } from "./enumerations";
+import type { ReadonlyNonEmptyArray } from "./types";
 
 /**
  * The maximum allows value for either minutes and seconds in a duration node.
@@ -80,7 +81,13 @@ function lintDuplicatePaceNameDefinition(
   if (paceDefinitionNode === null) return;
 
   if (declaredIdentifiers.has(node_value)) {
-    diagnostics.push(duplicatePaceNameDefinitionDiagnostic(node_value, node, paceDefinitionNode));
+    diagnostics.push(
+      duplicatePaceNameDefinitionDiagnostic(
+        node_value,
+        node,
+        paceDefinitionNode,
+      ),
+    );
   } else {
     declaredIdentifiers.add(node_value);
   }
@@ -190,7 +197,7 @@ function lintInvalidNodeValue(
   node: SyntaxNodeRef,
   editorState: EditorState,
   nodeName: string,
-  validValues: string[],
+  validValues: ReadonlyNonEmptyArray<string>,
   diagnostics: Diagnostic[],
 ): void {
   if (node.name !== nodeName) return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+export type ReadonlyNonEmptyArray<T> = readonly [T, ...T[]];
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as Levenshtein from "fastest-levenshtein";
+import type { ReadonlyNonEmptyArray } from "./types";
 
 /**
  * Find the string within `array` which is most similar to `str`.
@@ -11,25 +12,16 @@ import * as Levenshtein from "fastest-levenshtein";
  */
 export function closestLevenshtienDistance(
   str: string,
-  array: string[],
+  array: ReadonlyNonEmptyArray<string>,
 ): [string, number] {
-  let min_distance = Infinity;
-  let min_index = 0;
+  const [first, ...rest] = array;
 
-  for (let i = 0; i < array.length; i++) {
-    // Because of `"noUncheckedIndexedAccess": true` in tsconfig, array accesses
-    // return a type of `T | undefined`. As we know here that `i < array.length`
-    // the non-null assertion operator is appropriate.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const dist = Levenshtein.distance(str, array[i]!);
+  return rest.reduce(
+    ([minStr, minDist], item) => {
+      const dist = Levenshtein.distance(str, item);
 
-    if (dist < min_distance) {
-      min_distance = dist;
-      min_index = i;
-    }
-  }
-
-  // Read above comment
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return [array[min_index]!, min_distance];
+      return dist < minDist ? [item, dist] : [minStr, minDist];
+    },
+    [first, Levenshtein.distance(str, first)],
+  );
 }


### PR DESCRIPTION
While tightening the TypeScript configuration for #27, I spotted an edge case where the return value of the `closestLevenshtienDistance` util function returned a value outside the scope of the function's defined return type. The problem was that when the `array` parameter was given the argument of the empty array, `[]`, the function would return `[undefined, Infinity]`, which is of type `[undefined, number]`, not `[string, number]`. To minimise the scope of the PR, I silenced the error by using the non-null assertion operator, leaving the behavior of the program completely untouched. I  was unsatisfied with this however and sought to find a much safer solution, which I have done, in the form of this PR.

The solution, was to change the type of the `array` parameter from "array of strings", to "non-empty array of strings". In TypeScript this is expressed as a variadic tuple,  `[string, ...string[]]`. This means that to call `closestLevenshtienDistance`, you must provide an array that is not empty, meaning that `string[]` is not allowed! There are currently two call-points of `closestLevenshtienDistance` in the code. One of these was able to satisfy this constraint without runtime implication as it was always passing array's whose values were known at compile time. The second call-point required a simple `if` condition and a type assertion.