### PR TITLE
feat(underwater-instruction): Added new underwater instruction modifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "codemirror-lang-swimdsl",
       "version": "0.1.0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/language": "^6.11.0",
@@ -942,7 +943,6 @@
       "integrity": "sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.0",
         "@typescript-eslint/types": "8.32.0",
@@ -1162,7 +1162,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1519,7 +1518,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2262,7 +2260,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2747,7 +2744,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.1.tgz",
       "integrity": "sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -2997,8 +2993,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3018,7 +3013,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -13,6 +13,10 @@ export const enum InstructionModifiers {
   TIME,
 }
 
+export const enum StrokeModifiers {
+  UNDERWATER,
+}
+
 export interface Programme {
   statements: Statement[];
 }
@@ -49,13 +53,20 @@ export interface Time {
   seconds: string;
 }
 
+export interface Underwater {
+  modifier: StrokeModifiers.UNDERWATER;
+  isTrue: boolean;
+}
+
+export type StrokeModifier = Underwater;
+
 export type InstructionModifier = EquipmentSpecification | Pace | Time;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
   repetitions: number;
   instruction: SingleInstruction | BlockInstruction;
-  strokeModifier: string;
+  strokeModifier: StrokeModifier[];
   instructionModifiers: InstructionModifier[];
 }
 

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -14,11 +14,6 @@ export const enum InstructionModifiers {
   UNDERWATER,
 }
 
-// export const enum StrokeModifiers {
-//   UNDERWATER,
-//   STROKE_TYPE
-// }
-
 export interface Programme {
   statements: Statement[];
 }
@@ -60,20 +55,12 @@ export interface Underwater {
   isTrue: boolean;
 }
 
-// // Placeholder for the Kick | Pull | Drill
-// export interface StrokeType {
-//   modifier: StrokeModifiers.STROKE_TYPE
-// }
-
-// export type StrokeModifier = Underwater | StrokeType;
-
 export type InstructionModifier = EquipmentSpecification | Pace | Time | Underwater;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
   repetitions: number;
   instruction: SingleInstruction | BlockInstruction;
-  // strokeModifier: StrokeModifier[];
   strokeModifier: string;
   instructionModifiers: InstructionModifier[];
 }

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -15,6 +15,7 @@ export const enum InstructionModifiers {
 
 export const enum StrokeModifiers {
   UNDERWATER,
+  STROKE_TYPE
 }
 
 export interface Programme {
@@ -58,7 +59,12 @@ export interface Underwater {
   isTrue: boolean;
 }
 
-export type StrokeModifier = Underwater;
+// Placeholder for the Kick | Pull | Drill
+export interface StrokeType {
+  modifier: StrokeModifiers.STROKE_TYPE
+}
+
+export type StrokeModifier = Underwater | StrokeType;
 
 export type InstructionModifier = EquipmentSpecification | Pace | Time;
 

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -55,7 +55,11 @@ export interface Underwater {
   isTrue: boolean;
 }
 
-export type InstructionModifier = EquipmentSpecification | Pace | Time | Underwater;
+export type InstructionModifier =
+  | EquipmentSpecification
+  | Pace
+  | Time
+  | Underwater;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -11,12 +11,13 @@ export const enum InstructionModifiers {
   EQUIPMENT_SPECIFICATION,
   PACE,
   TIME,
+  UNDERWATER,
 }
 
-export const enum StrokeModifiers {
-  UNDERWATER,
-  STROKE_TYPE
-}
+// export const enum StrokeModifiers {
+//   UNDERWATER,
+//   STROKE_TYPE
+// }
 
 export interface Programme {
   statements: Statement[];
@@ -55,24 +56,25 @@ export interface Time {
 }
 
 export interface Underwater {
-  modifier: StrokeModifiers.UNDERWATER;
+  modifier: InstructionModifiers.UNDERWATER;
   isTrue: boolean;
 }
 
-// Placeholder for the Kick | Pull | Drill
-export interface StrokeType {
-  modifier: StrokeModifiers.STROKE_TYPE
-}
+// // Placeholder for the Kick | Pull | Drill
+// export interface StrokeType {
+//   modifier: StrokeModifiers.STROKE_TYPE
+// }
 
-export type StrokeModifier = Underwater | StrokeType;
+// export type StrokeModifier = Underwater | StrokeType;
 
-export type InstructionModifier = EquipmentSpecification | Pace | Time;
+export type InstructionModifier = EquipmentSpecification | Pace | Time | Underwater;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
   repetitions: number;
   instruction: SingleInstruction | BlockInstruction;
-  strokeModifier: StrokeModifier[];
+  // strokeModifier: StrokeModifier[];
+  strokeModifier: string;
   instructionModifiers: InstructionModifier[];
 }
 

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -15,7 +15,6 @@ import {
   SingleInstruction,
   Statement,
   Statements,
-  // StrokeModifiers,
   SwimInstruction,
 } from "./astTypes";
 import {EditorState} from "@codemirror/state";
@@ -241,36 +240,6 @@ function visitInstructionModifier(
   };
 }
 
-// /**
-//  * Create an AST node for an `instructionModifier` CST node.
-//  * Precondition: `cursor` points to one of `EquipmentSpecification`, `Pace`, or
-//  * `Duration`.
-//  *
-//  * Postcondition: `cursor` will point to the same node it pointed to when
-//  * passed to this function.
-//  */
-// function visitStrokeModifier(
-//   cursor: TreeCursor,
-//   state: EditorState,
-// ): StrokeModifier {
-//
-//   const strokeModifier = state.sliceDoc(cursor.from, cursor.to);
-//
-//   if (strokeModifier === "Underwater") {
-//     console.log("Underwater")
-//     return {
-//       modifier: StrokeModifiers.UNDERWATER,
-//       isTrue: true,
-//     }
-//   }
-//   else {
-//     console.log("Cursor:", cursor.name);
-//     return {
-//       modifier: StrokeModifiers.STROKE_TYPE
-//     }
-//   }
-// }
-
 /**
  * Convert the swimDSL stroke name to the swiML stroke name.
  *
@@ -425,14 +394,6 @@ function visitSwimInstruction(
     let hasModifiers = true;
     if (cursor.name === "StrokeModifier") {
       strokeModifier = state.sliceDoc(cursor.from, cursor.to);
-
-      //// StrokeModifier attepmt
-      // strokeModifier.push(visitStrokeModifier(cursor, state));
-      // do {
-      //   strokeModifier.push(visitStrokeModifier(cursor, state));
-      //   cursor.nextSibling();
-      // } while (cursor.name === "StrokeModifier");
-      // cursor.parent();
 
       // Move away from the StrokeModifier to a potential instruction modifier.
       hasModifiers = cursor.nextSibling();

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -1,4 +1,4 @@
-import {TreeCursor} from "@lezer/common";
+import { TreeCursor } from "@lezer/common";
 import {
   AuthorDefintion,
   BlockInstruction,
@@ -17,7 +17,7 @@ import {
   Statements,
   SwimInstruction,
 } from "./astTypes";
-import {EditorState} from "@codemirror/state";
+import { EditorState } from "@codemirror/state";
 
 /**
  * Create an AST node for a `Pace` CST node.
@@ -230,7 +230,7 @@ function visitInstructionModifier(
     return {
       modifier: InstructionModifiers.UNDERWATER,
       isTrue: true,
-    }
+    };
   }
 
   // We are in Duration

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -244,15 +244,26 @@ function visitInstructionModifier(
  * passed to this function.
  */
 function visitStrokeModifier(
-  // cursor: TreeCursor,
-  // state: EditorState,
+  cursor: TreeCursor,
+  state: EditorState,
 ): StrokeModifier {
 
-  // Underwater is the only stroke modifier currently.
-  return {
-    modifier: StrokeModifiers.UNDERWATER,
-    isTrue: true,
+  const strokeModifier = state.sliceDoc(cursor.from, cursor.to);
+
+  if (strokeModifier === "Underwater") {
+    console.log("Underwater")
+    return {
+      modifier: StrokeModifiers.UNDERWATER,
+      isTrue: true,
+    }
   }
+  else {
+    console.log("Cursor:", cursor.name);
+    return {
+      modifier: StrokeModifiers.STROKE_TYPE
+    }
+  }
+
 
 }
 
@@ -409,8 +420,9 @@ function visitSwimInstruction(
     let hasModifiers = true;
     if (cursor.name === "StrokeModifier") {
       // strokeModifier = state.sliceDoc(cursor.from, cursor.to);
-      strokeModifier.push(visitStrokeModifier());
+      strokeModifier.push(visitStrokeModifier(cursor, state));
       // Move away from the StrokeModifier to a potential instruction modifier.
+      cursor.parent();
       hasModifiers = cursor.nextSibling();
     }
 

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -350,7 +350,6 @@ function visitSwimInstruction(
   state: EditorState,
 ): SwimInstruction {
   let repetitions = 1;
-  // let strokeModifier: StrokeModifier[] = [];
   let strokeModifier = "default";
   let instruction: SingleInstruction | BlockInstruction;
   const instructionModifiers: InstructionModifier[] = [];

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -1,4 +1,4 @@
-import { TreeCursor } from "@lezer/common";
+import {TreeCursor} from "@lezer/common";
 import {
   AuthorDefintion,
   BlockInstruction,
@@ -15,9 +15,11 @@ import {
   SingleInstruction,
   Statement,
   Statements,
+  StrokeModifier,
+  StrokeModifiers,
   SwimInstruction,
 } from "./astTypes";
-import { EditorState } from "@codemirror/state";
+import {EditorState} from "@codemirror/state";
 
 /**
  * Create an AST node for a `Pace` CST node.
@@ -234,6 +236,27 @@ function visitInstructionModifier(
 }
 
 /**
+ * Create an AST node for an `instructionModifier` CST node.
+ * Precondition: `cursor` points to one of `EquipmentSpecification`, `Pace`, or
+ * `Duration`.
+ *
+ * Postcondition: `cursor` will point to the same node it pointed to when
+ * passed to this function.
+ */
+function visitStrokeModifier(
+  // cursor: TreeCursor,
+  // state: EditorState,
+): StrokeModifier {
+
+  // Underwater is the only stroke modifier currently.
+  return {
+    modifier: StrokeModifiers.UNDERWATER,
+    isTrue: true,
+  }
+
+}
+
+/**
  * Convert the swimDSL stroke name to the swiML stroke name.
  *
  * @param strokeName - The swimDSL name of stroke.
@@ -343,7 +366,7 @@ function visitSwimInstruction(
   state: EditorState,
 ): SwimInstruction {
   let repetitions = 1;
-  let strokeModifier = "default";
+  let strokeModifier: StrokeModifier[] = [];
   let instruction: SingleInstruction | BlockInstruction;
   const instructionModifiers: InstructionModifier[] = [];
 
@@ -385,8 +408,8 @@ function visitSwimInstruction(
   if (cursor.nextSibling()) {
     let hasModifiers = true;
     if (cursor.name === "StrokeModifier") {
-      strokeModifier = state.sliceDoc(cursor.from, cursor.to);
-
+      // strokeModifier = state.sliceDoc(cursor.from, cursor.to);
+      strokeModifier.push(visitStrokeModifier());
       // Move away from the StrokeModifier to a potential instruction modifier.
       hasModifiers = cursor.nextSibling();
     }

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -15,8 +15,7 @@ import {
   SingleInstruction,
   Statement,
   Statements,
-  StrokeModifier,
-  StrokeModifiers,
+  // StrokeModifiers,
   SwimInstruction,
 } from "./astTypes";
 import {EditorState} from "@codemirror/state";
@@ -228,6 +227,13 @@ function visitInstructionModifier(
     return visitPace(cursor, state);
   }
 
+  if (cursor.name === "Underwater") {
+    return {
+      modifier: InstructionModifiers.UNDERWATER,
+      isTrue: true,
+    }
+  }
+
   // We are in Duration
   return {
     modifier: InstructionModifiers.TIME,
@@ -235,37 +241,35 @@ function visitInstructionModifier(
   };
 }
 
-/**
- * Create an AST node for an `instructionModifier` CST node.
- * Precondition: `cursor` points to one of `EquipmentSpecification`, `Pace`, or
- * `Duration`.
- *
- * Postcondition: `cursor` will point to the same node it pointed to when
- * passed to this function.
- */
-function visitStrokeModifier(
-  cursor: TreeCursor,
-  state: EditorState,
-): StrokeModifier {
-
-  const strokeModifier = state.sliceDoc(cursor.from, cursor.to);
-
-  if (strokeModifier === "Underwater") {
-    console.log("Underwater")
-    return {
-      modifier: StrokeModifiers.UNDERWATER,
-      isTrue: true,
-    }
-  }
-  else {
-    console.log("Cursor:", cursor.name);
-    return {
-      modifier: StrokeModifiers.STROKE_TYPE
-    }
-  }
-
-
-}
+// /**
+//  * Create an AST node for an `instructionModifier` CST node.
+//  * Precondition: `cursor` points to one of `EquipmentSpecification`, `Pace`, or
+//  * `Duration`.
+//  *
+//  * Postcondition: `cursor` will point to the same node it pointed to when
+//  * passed to this function.
+//  */
+// function visitStrokeModifier(
+//   cursor: TreeCursor,
+//   state: EditorState,
+// ): StrokeModifier {
+//
+//   const strokeModifier = state.sliceDoc(cursor.from, cursor.to);
+//
+//   if (strokeModifier === "Underwater") {
+//     console.log("Underwater")
+//     return {
+//       modifier: StrokeModifiers.UNDERWATER,
+//       isTrue: true,
+//     }
+//   }
+//   else {
+//     console.log("Cursor:", cursor.name);
+//     return {
+//       modifier: StrokeModifiers.STROKE_TYPE
+//     }
+//   }
+// }
 
 /**
  * Convert the swimDSL stroke name to the swiML stroke name.
@@ -377,7 +381,8 @@ function visitSwimInstruction(
   state: EditorState,
 ): SwimInstruction {
   let repetitions = 1;
-  let strokeModifier: StrokeModifier[] = [];
+  // let strokeModifier: StrokeModifier[] = [];
+  let strokeModifier = "default";
   let instruction: SingleInstruction | BlockInstruction;
   const instructionModifiers: InstructionModifier[] = [];
 
@@ -419,10 +424,17 @@ function visitSwimInstruction(
   if (cursor.nextSibling()) {
     let hasModifiers = true;
     if (cursor.name === "StrokeModifier") {
-      // strokeModifier = state.sliceDoc(cursor.from, cursor.to);
-      strokeModifier.push(visitStrokeModifier(cursor, state));
+      strokeModifier = state.sliceDoc(cursor.from, cursor.to);
+
+      //// StrokeModifier attepmt
+      // strokeModifier.push(visitStrokeModifier(cursor, state));
+      // do {
+      //   strokeModifier.push(visitStrokeModifier(cursor, state));
+      //   cursor.nextSibling();
+      // } while (cursor.name === "StrokeModifier");
+      // cursor.parent();
+
       // Move away from the StrokeModifier to a potential instruction modifier.
-      cursor.parent();
       hasModifiers = cursor.nextSibling();
     }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -67,7 +67,7 @@ const nodeCompletions: Record<CompletableNodes, NodeCompletionSpec> = {
   },
   [CompletableNodes.STROKE_MODIFIER]: {
     priorNodeName: "",
-    nodeName: "StrokeType",
+    nodeName: "StrokeModifier",
     completions: strokeModifierCompletions,
   },
   [CompletableNodes.CONSTANT_NAME]: {

--- a/src/enumerations.ts
+++ b/src/enumerations.ts
@@ -51,7 +51,7 @@ export const strokeNames = [
 /**
  * The list of all strings considered valid in place of a stroke type.
  */
-export const strokeTypes = ["Pull", "Kick", "Drill"] as const;
+export const strokeTypes = ["Pull", "Kick", "Drill", "Underwater"] as const;
 
 /**
  * The list of all strings considered valid in place of an equipment name.

--- a/src/enumerations.ts
+++ b/src/enumerations.ts
@@ -51,7 +51,7 @@ export const strokeNames = [
 /**
  * The list of all strings considered valid in place of a stroke type.
  */
-export const strokeTypes = ["Pull", "Kick", "Drill", "Underwater"] as const;
+export const strokeTypes = ["Pull", "Kick", "Drill"] as const;
 
 /**
  * The list of all strings considered valid in place of an equipment name.

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -10,8 +10,6 @@ import {
   Programme,
   RestInstruction,
   Statements,
-  // StrokeModifier,
-  // StrokeModifiers,
   SwimInstruction,
 } from "./astTypes";
 import {XMLBuilder} from "xmlbuilder2/lib/interfaces";

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -122,24 +122,6 @@ function writeInstructionModifier(
   }
 }
 
-// /**
-//  * Write an AST StrokeModifier node into the XML document.
-//  *
-//  * @param xmlParent - The parent XML node to write the instruction modifier
-//  *    inside of
-//  * @param modifier - The AST instruction modifier node to write as XML.
-//  */
-// function writeStrokeModifier(
-//   xmlParent: XMLBuilder,
-//   modifier: StrokeModifier,
-// ): void {
-//   switch (modifier.modifier) {
-//     case StrokeModifiers.UNDERWATER:
-//       xmlParent.ele("underwater").txt(modifier.isTrue.toString());
-//       break;
-//   }
-// }
-
 /**
  * Write an AST SwimInstruction node into the XML document.
  *
@@ -171,11 +153,6 @@ function writeSwimInstruction(
       .ele("standardStroke")
       .txt(instruction.instruction.stroke);
   }
-  // if (instruction.strokeModifier.length > 0) {
-  //   for (const modifier of instruction.strokeModifier) {
-  //     writeStrokeModifier(parent, modifier);
-  //   }
-  // }
   if (instruction.instructionModifiers.length > 0) {
     for (const modifier of instruction.instructionModifiers) {
       writeInstructionModifier(parent, modifier);

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -1,4 +1,4 @@
-import { create } from "xmlbuilder2";
+import {create} from "xmlbuilder2";
 import {
   AuthorDefintion,
   ConstantDefinition,
@@ -10,9 +10,11 @@ import {
   Programme,
   RestInstruction,
   Statements,
+  StrokeModifier,
+  StrokeModifiers,
   SwimInstruction,
 } from "./astTypes";
-import { XMLBuilder } from "xmlbuilder2/lib/interfaces";
+import {XMLBuilder} from "xmlbuilder2/lib/interfaces";
 
 const XML_NAMESPACE = "https://github.com/bartneck/swiML";
 const XSI_LINK = "http://www.w3.org/2001/XMLSchema-instance";
@@ -116,6 +118,24 @@ function writeInstructionModifier(
 }
 
 /**
+ * Write an AST StrokeModifier node into the XML document.
+ *
+ * @param xmlParent - The parent XML node to write the instruction modifier
+ *    inside of
+ * @param modifier - The AST instruction modifier node to write as XML.
+ */
+function writeStrokeModifier(
+  xmlParent: XMLBuilder,
+  modifier: StrokeModifier,
+): void {
+  switch (modifier.modifier) {
+    case StrokeModifiers.UNDERWATER:
+      xmlParent.ele("underwater").txt(modifier.isTrue.toString());
+      break;
+  }
+}
+
+/**
  * Write an AST SwimInstruction node into the XML document.
  *
  * @param xmlParent - The parent XML node to write the instruction inside of.
@@ -146,7 +166,11 @@ function writeSwimInstruction(
       .ele("standardStroke")
       .txt(instruction.instruction.stroke);
   }
-
+  if (instruction.strokeModifier.length > 0) {
+    for (const modifier of instruction.strokeModifier) {
+      writeStrokeModifier(parent, modifier);
+    }
+  }
   if (instruction.instructionModifiers.length > 0) {
     for (const modifier of instruction.instructionModifiers) {
       writeInstructionModifier(parent, modifier);

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -1,4 +1,4 @@
-import {create} from "xmlbuilder2";
+import { create } from "xmlbuilder2";
 import {
   AuthorDefintion,
   ConstantDefinition,
@@ -12,7 +12,7 @@ import {
   Statements,
   SwimInstruction,
 } from "./astTypes";
-import {XMLBuilder} from "xmlbuilder2/lib/interfaces";
+import { XMLBuilder } from "xmlbuilder2/lib/interfaces";
 
 const XML_NAMESPACE = "https://github.com/bartneck/swiML";
 const XSI_LINK = "http://www.w3.org/2001/XMLSchema-instance";
@@ -114,8 +114,7 @@ function writeInstructionModifier(
       break;
 
     case InstructionModifiers.UNDERWATER:
-      xmlParent
-        .ele("underwater").txt(modifier.isTrue.toString())
+      xmlParent.ele("underwater").txt(modifier.isTrue.toString());
       break;
   }
 }
@@ -151,6 +150,7 @@ function writeSwimInstruction(
       .ele("standardStroke")
       .txt(instruction.instruction.stroke);
   }
+
   if (instruction.instructionModifiers.length > 0) {
     for (const modifier of instruction.instructionModifiers) {
       writeInstructionModifier(parent, modifier);

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -10,8 +10,8 @@ import {
   Programme,
   RestInstruction,
   Statements,
-  StrokeModifier,
-  StrokeModifiers,
+  // StrokeModifier,
+  // StrokeModifiers,
   SwimInstruction,
 } from "./astTypes";
 import {XMLBuilder} from "xmlbuilder2/lib/interfaces";
@@ -114,26 +114,31 @@ function writeInstructionModifier(
         .ele("sinceStart")
         .txt(xmlDuration(modifier.minutes, modifier.seconds));
       break;
-  }
-}
 
-/**
- * Write an AST StrokeModifier node into the XML document.
- *
- * @param xmlParent - The parent XML node to write the instruction modifier
- *    inside of
- * @param modifier - The AST instruction modifier node to write as XML.
- */
-function writeStrokeModifier(
-  xmlParent: XMLBuilder,
-  modifier: StrokeModifier,
-): void {
-  switch (modifier.modifier) {
-    case StrokeModifiers.UNDERWATER:
-      xmlParent.ele("underwater").txt(modifier.isTrue.toString());
+    case InstructionModifiers.UNDERWATER:
+      xmlParent
+        .ele("underwater").txt(modifier.isTrue.toString())
       break;
   }
 }
+
+// /**
+//  * Write an AST StrokeModifier node into the XML document.
+//  *
+//  * @param xmlParent - The parent XML node to write the instruction modifier
+//  *    inside of
+//  * @param modifier - The AST instruction modifier node to write as XML.
+//  */
+// function writeStrokeModifier(
+//   xmlParent: XMLBuilder,
+//   modifier: StrokeModifier,
+// ): void {
+//   switch (modifier.modifier) {
+//     case StrokeModifiers.UNDERWATER:
+//       xmlParent.ele("underwater").txt(modifier.isTrue.toString());
+//       break;
+//   }
+// }
 
 /**
  * Write an AST SwimInstruction node into the XML document.
@@ -166,11 +171,11 @@ function writeSwimInstruction(
       .ele("standardStroke")
       .txt(instruction.instruction.stroke);
   }
-  if (instruction.strokeModifier.length > 0) {
-    for (const modifier of instruction.strokeModifier) {
-      writeStrokeModifier(parent, modifier);
-    }
-  }
+  // if (instruction.strokeModifier.length > 0) {
+  //   for (const modifier of instruction.strokeModifier) {
+  //     writeStrokeModifier(parent, modifier);
+  //   }
+  // }
   if (instruction.instructionModifiers.length > 0) {
     for (const modifier of instruction.instructionModifiers) {
       writeInstructionModifier(parent, modifier);
@@ -261,7 +266,7 @@ function writeConstantDefinition(
  *
  * @param xmlParent - The parent XML node to write the author definition inside
  *    of.
- * @param instruction - The AST author definition node to write as XML.
+ * @param definition - The AST author definition node to write as XML.
  */
 function writeAuthorDefinition(
   xmlParent: XMLBuilder,

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -72,12 +72,14 @@ BlockInstruction {
     "{" instruction+ "}"
 }
 
-StrokeModifier {
-    identifier
+StrokeModifier { identifier }
+
+Underwater {
+    underwaterKeyword
 }
 
 instructionModifier {
-  EquipmentSpecification | paceSpecification | timeSpecification
+  EquipmentSpecification | paceSpecification | timeSpecification | Underwater
 }
 
 EquipmentSpecification {
@@ -112,6 +114,7 @@ messageSpecification {
     paceKeyword           { "pace" }
     restKeyword           { "rest" }
     onKeyword             { "on" }
+    underwaterKeyword     { "Underwater" }
     space       { @whitespace+ }
     Comment     { "#" ![\n]* }
     Number      { @digit+ }
@@ -128,6 +131,7 @@ messageSpecification {
     @precedence { onKeyword, identifier }
     @precedence { space, Message }
     @precedence { Comment, Message }
+    @precedence { underwaterKeyword, identifier }
 }
 
 @skip { space | Comment }

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -72,7 +72,9 @@ BlockInstruction {
     "{" instruction+ "}"
 }
 
-StrokeModifier { identifier }
+StrokeModifier {
+    identifier
+}
 
 instructionModifier {
   EquipmentSpecification | paceSpecification | timeSpecification


### PR DESCRIPTION
To allow the user to model underwater swimming I have added the Underwater instruction modifier which adds the Underwater tag to the instruction as per the swiML schema.

<img width="2556" height="261" alt="image" src="https://github.com/user-attachments/assets/bce53ffb-6325-4c2b-bb8b-e80f3fbaec52" />

Closes #10 