### PR TITLE
feat(breath-instruction): Added new breathe instruction modifier

### DIFF
--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -11,6 +11,7 @@ export const enum InstructionModifiers {
   EQUIPMENT_SPECIFICATION,
   PACE,
   TIME,
+  BREATHE,
 }
 
 export interface Programme {
@@ -49,7 +50,7 @@ export interface Time {
   seconds: string;
 }
 
-export type InstructionModifier = EquipmentSpecification | Pace | Time;
+export type InstructionModifier = EquipmentSpecification | Pace | Time | Breathe;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
@@ -96,4 +97,9 @@ export interface PaceDefinition {
 export interface Message {
   statement: Statements.MESSAGE;
   message: string;
+}
+
+export interface Breathe {
+  modifier: InstructionModifiers.BREATHE;
+  breatheStrokes: string;
 }

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -1,7 +1,8 @@
-import { TreeCursor } from "@lezer/common";
+import {TreeCursor} from "@lezer/common";
 import {
   AuthorDefintion,
   BlockInstruction,
+  Breathe,
   ConstantDefinition,
   Instruction,
   InstructionModifier,
@@ -90,6 +91,32 @@ function visitPaceDefinition(
   cursor.parent();
 
   return { statement: Statements.PACE_DEFINITION, name, pace };
+}
+
+/**
+ * Creates an AST node for `Breathe` CST node
+ *
+ * Precondition: `cursor` points to a `Breathe`.
+ *
+ * Postcondition: `cursor` will point to the same node it pointed to when
+ * passed to this function.
+ *
+ * @param cursor - A reference to a Lezer syntax tree node.
+ * @param state - The state of the CodeMirror editor.
+ *
+ * @returns A `Breathe` AST node
+ */
+function visitBreathe(cursor: TreeCursor, state: EditorState): Breathe {
+  // Move into the breatheStrokes value
+  cursor.firstChild();
+  const breatheStrokes = state.sliceDoc(cursor.from, cursor.to);
+
+  // Step back up to the Breathe
+  cursor.parent();
+  return {
+    modifier: InstructionModifiers.BREATHE,
+    breatheStrokes: breatheStrokes,
+  }
 }
 
 /**
@@ -224,6 +251,10 @@ function visitInstructionModifier(
 
   if (cursor.name === "Pace") {
     return visitPace(cursor, state);
+  }
+
+  if (cursor.name === "Breathe") {
+    return visitBreathe(cursor, state);
   }
 
   // We are in Duration

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -116,7 +116,7 @@ function visitBreathe(cursor: TreeCursor, state: EditorState): Breathe {
   return {
     modifier: InstructionModifiers.BREATHE,
     breatheStrokes: breatheStrokes,
-  }
+  };
 }
 
 /**

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -106,6 +106,12 @@ function writeInstructionModifier(
       }
       break;
 
+    case InstructionModifiers.BREATHE:
+      xmlParent
+        .ele("breath")
+        .txt(modifier.breatheStrokes)
+      break;
+
     case InstructionModifiers.TIME:
       xmlParent
         .ele("rest")
@@ -237,7 +243,7 @@ function writeConstantDefinition(
  *
  * @param xmlParent - The parent XML node to write the author definition inside
  *    of.
- * @param instruction - The AST author definition node to write as XML.
+ * @param definition - The AST author definition node to write as XML.
  */
 function writeAuthorDefinition(
   xmlParent: XMLBuilder,

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -107,9 +107,7 @@ function writeInstructionModifier(
       break;
 
     case InstructionModifiers.BREATHE:
-      xmlParent
-        .ele("breath")
-        .txt(modifier.breatheStrokes)
+      xmlParent.ele("breath").txt(modifier.breatheStrokes);
       break;
 
     case InstructionModifiers.TIME:

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -79,7 +79,11 @@ Underwater {
 }
 
 instructionModifier {
-  EquipmentSpecification | paceSpecification | timeSpecification | Underwater | Breathe
+    EquipmentSpecification
+    | paceSpecification
+    | timeSpecification
+    | Underwater
+    | Breathe
 }
 
 Breathe {

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -75,7 +75,11 @@ BlockInstruction {
 StrokeModifier { identifier }
 
 instructionModifier {
-  EquipmentSpecification | paceSpecification | timeSpecification
+  EquipmentSpecification | paceSpecification | timeSpecification | Breathe
+}
+
+Breathe {
+    breatheKeyword Number
 }
 
 EquipmentSpecification {
@@ -110,6 +114,7 @@ messageSpecification {
     paceKeyword           { "pace" }
     restKeyword           { "rest" }
     onKeyword             { "on" }
+    breatheKeyword        { "breathe" }
     space       { @whitespace+ }
     Comment     { "#" ![\n]* }
     Number      { @digit+ }
@@ -126,6 +131,7 @@ messageSpecification {
     @precedence { onKeyword, identifier }
     @precedence { space, Message }
     @precedence { Comment, Message }
+    @precedence { breatheKeyword, identifier }
 }
 
 @skip { space | Comment }


### PR DESCRIPTION
To allow the user to model breathing after a certain amount of strokes I have added the breathe instruction modifier which adds the breath tag to the instruction as per the swiML schema.

<img width="2559" height="233" alt="image" src="https://github.com/user-attachments/assets/c19e52be-f602-4e03-93d5-131060ab4be7" />

Closes #9 