### PR TITLE
feat(instruction-rest): Added implementation for different instruction rest types 

### DIFF
--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -12,7 +12,6 @@ export const enum InstructionModifiers {
   REST,
   BREATHE,
   UNDERWATER,
-  IN_OUT,
   INSTRUCTION_DESCRIPTION,
 }
 
@@ -70,8 +69,7 @@ export type InstructionModifier =
   | Rest
   | Underwater
   | Breathe
-  | InstructionDescription
-  | InOut;
+  | InstructionDescription;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
@@ -117,9 +115,4 @@ export interface Message {
 export interface Breathe {
   modifier: InstructionModifiers.BREATHE;
   breatheStrokes: string;
-}
-
-export interface InOut {
-  modifier: InstructionModifiers.IN_OUT;
-  swimmersIn: string;
 }

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -47,6 +47,7 @@ export interface EquipmentSpecification {
 
 export interface Time {
   modifier: InstructionModifiers.TIME;
+  keyWord: string;
   minutes: string;
   seconds: string;
 }

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -13,6 +13,7 @@ export const enum InstructionModifiers {
   TIME,
   BREATHE,
   UNDERWATER,
+  IN_OUT,
 }
 
 export interface Programme {
@@ -62,7 +63,8 @@ export type InstructionModifier =
   | Pace
   | Time
   | Underwater
-  | Breathe;
+  | Breathe
+  | InOut;
 
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
@@ -114,4 +116,9 @@ export interface Message {
 export interface Breathe {
   modifier: InstructionModifiers.BREATHE;
   breatheStrokes: string;
+}
+
+export interface InOut {
+  modifier: InstructionModifiers.IN_OUT;
+  swimmersIn: string;
 }

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -55,12 +55,26 @@ export interface InstructionDescription {
   description: string;
 }
 
-export interface Rest {
+export type Rest = RestSinceStart | RestAfterStop | RestInOut;
+
+export interface RestSinceStart {
   modifier: InstructionModifiers.REST;
-  keyWord: string;
-  minutes?: string;
-  seconds?: string;
-  swimmersIn?: string;
+  type: "SinceStart";
+  minutes: string;
+  seconds: string
+}
+
+export interface RestAfterStop {
+  modifier: InstructionModifiers.REST;
+  type: "AfterStop";
+  minutes: string;
+  seconds: string;
+}
+
+export interface RestInOut {
+  modifier: InstructionModifiers.REST;
+  type: "InOut";
+  swimmersIn: string;
 }
 
 export interface Underwater {

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -9,7 +9,7 @@ export const enum Statements {
 export const enum InstructionModifiers {
   EQUIPMENT_SPECIFICATION,
   PACE,
-  TIME,
+  REST,
   BREATHE,
   UNDERWATER,
   IN_OUT,
@@ -51,11 +51,12 @@ export interface InstructionDescription {
   description: string;
 }
 
-export interface Time {
-  modifier: InstructionModifiers.TIME;
+export interface Rest {
+  modifier: InstructionModifiers.REST;
   keyWord: string;
-  minutes: string;
-  seconds: string;
+  minutes?: string;
+  seconds?: string;
+  swimmersIn?: string;
 }
 
 export interface Underwater {
@@ -66,7 +67,7 @@ export interface Underwater {
 export type InstructionModifier =
   | EquipmentSpecification
   | Pace
-  | Time
+  | Rest
   | Underwater
   | Breathe
   | InstructionDescription

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -1,6 +1,5 @@
 export const enum Statements {
   SWIM_INSTRUCTION,
-  REST_INSTRUCTION,
   MESSAGE,
   PACE_DEFINITION,
   CONSTANT_DEFINITION,
@@ -20,7 +19,7 @@ export interface Programme {
   statements: Statement[];
 }
 
-export type Instruction = SwimInstruction | RestInstruction | Message;
+export type Instruction = SwimInstruction | Message;
 
 export interface ConstantDefinition {
   statement: Statements.CONSTANT_DEFINITION;
@@ -83,12 +82,6 @@ export interface SingleInstruction {
 export interface BlockInstruction {
   isBlock: true;
   instructions: Instruction[];
-}
-
-export interface RestInstruction {
-  statement: Statements.REST_INSTRUCTION;
-  minutes: string;
-  seconds: string;
 }
 
 export interface Intensity {

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -1,6 +1,5 @@
 export const enum Statements {
   SWIM_INSTRUCTION,
-  REST_INSTRUCTION,
   MESSAGE,
   PACE_DEFINITION,
   CONSTANT_DEFINITION,
@@ -25,7 +24,7 @@ export interface Programme {
   statements: Statement[];
 }
 
-export type Instruction = SwimInstruction | RestInstruction | Message;
+export type Instruction = SwimInstruction | Message;
 
 export interface ConstantDefinition {
   statement: Statements.CONSTANT_DEFINITION;

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -265,8 +265,12 @@ function visitInstructionModifier(
   }
 
   // We are in Duration
+  // Get the specified rest keyword
+  const getType = state.wordAt(cursor.from - 1);
+  const restType = getType ? state.sliceDoc(getType.from, getType.to) : "";
   return {
     modifier: InstructionModifiers.TIME,
+    keyWord: restType,
     ...visitDuration(cursor, state),
   };
 }

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -264,6 +264,17 @@ function visitInstructionModifier(
     };
   }
 
+  if (cursor.name === "InOut") {
+    cursor.firstChild();
+    const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
+    cursor.parent();
+
+    return {
+      modifier: InstructionModifiers.IN_OUT,
+      swimmersIn,
+    };
+  }
+
   // We are in Duration
   // Get the specified rest keyword
   const getType = state.wordAt(cursor.from - 1);

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -12,7 +12,6 @@ import {
   Pace,
   PaceDefinition,
   Programme,
-  RestInstruction,
   SingleInstruction,
   Statement,
   Statements,
@@ -136,10 +135,6 @@ function visitBreathe(cursor: TreeCursor, state: EditorState): Breathe {
 function visitInstruction(cursor: TreeCursor, state: EditorState): Instruction {
   if (cursor.name === "SwimInstruction") {
     return visitSwimInstruction(cursor, state);
-  }
-
-  if (cursor.name === "RestInstruction") {
-    return visitRestInstruction(cursor, state);
   }
 
   return visitMessage(cursor, state);
@@ -464,37 +459,6 @@ function visitSwimInstruction(
 }
 
 /**
- * Create an AST node for a `RestInstruction` CST node.
- *
- * Precondition: `cursor` points to a `RestInstruction` node.
- *
- * Postcondition: `cursor` will point to the same node it pointed to when
- * passed to this function.
- *
- * @param cursor - A reference to a Lezer syntax tree node.
- * @param state - The state of the CodeMirror editor.
- *
- * @returns A `RestInstruction` AST node.
- */
-function visitRestInstruction(
-  cursor: TreeCursor,
-  state: EditorState,
-): RestInstruction {
-  // Move down to Duration
-  cursor.firstChild();
-
-  const duration = visitDuration(cursor, state);
-
-  // Move back up to RestInstruction
-  cursor.parent();
-
-  return {
-    statement: Statements.REST_INSTRUCTION,
-    ...duration,
-  };
-}
-
-/**
  * Create an AST node for a `Message` CST node.
  *
  * Precondition: `cursor` points to a `Message` node.
@@ -615,9 +579,6 @@ export default function buildAst(
       switch (cursor.type.name) {
         case "SwimInstruction":
           node = visitSwimInstruction(cursor, state);
-          break;
-        case "RestInstruction":
-          node = visitRestInstruction(cursor, state);
           break;
         case "Message":
           node = visitMessage(cursor, state);

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -274,28 +274,10 @@ function visitInstructionModifier(
     };
   }
 
-  // if (cursor.name === "InOut") {
-  //   cursor.firstChild();
-  //   const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
-  //   cursor.parent();
-  //
-  //   return {
-  //     modifier: InstructionModifiers.IN_OUT,
-  //     swimmersIn,
-  //   };
-  // }
-
   // We are in Duration
   // Get the specified rest keyword
   const getType = state.wordAt(cursor.from - 1);
-  let restType = getType ? state.sliceDoc(getType.from, getType.to) : "";
-  if (restType === "in") restType = "in-out";
-  // // console.log(restType);
-  // const textBefore = state.sliceDoc(0, cursor.from).trimEnd();
-  // // const match = textBefore.match(/(\S+)\s*$/);
-  // const restType = /(\S+)\s*$/.exec(textBefore)?.[1] ?? "";
-  console.log(restType);
-
+  const restType = getType ? state.sliceDoc(getType.from, getType.to) : "";
   const isDuration = ["on", "rest"];
   const durationResult = isDuration.includes(restType)
     ? visitDuration(cursor, state)
@@ -305,7 +287,6 @@ function visitInstructionModifier(
     modifier: InstructionModifiers.REST,
     keyWord: restType,
     ...durationResult,
-
   };
 }
 

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -13,6 +13,7 @@ import {
   Pace,
   PaceDefinition,
   Programme,
+  Rest,
   SingleInstruction,
   Statement,
   Statements,
@@ -269,20 +270,61 @@ function visitInstructionModifier(
   }
 
   // We are in Rest
-  // Get rest type
-  const restType: string = state.sliceDoc(cursor.from, cursor.to).split(" ")[0] ?? "";
-  // Step into first child i.e. Duration(timedRest) or Number(inOut)
-  cursor.firstChild();
-  const durationResult = restType === "in-out"
-    ? { swimmersIn: state.sliceDoc(cursor.from, cursor.to) }
-    : visitDuration(cursor, state);
-  // Step back to Rest
-  cursor.parent();
-  return {
-    modifier: InstructionModifiers.REST,
-    keyWord: restType,
-    ...durationResult,
-  };
+  return visitRest(cursor, state);
+}
+
+/**
+ * Create an AST node for a `Rest` CST node.
+ *
+ * Precondition: `cursor` points to a `Rest` node.
+ *
+ * Postcondition: `cursor` will point to the same node it pointed to when
+ * passed to this function.
+ *
+ * @param cursor - A reference to a Lezer syntax tree node.
+ * @param state - The state of the CodeMirror editor.
+ *
+ * @returns A `Rest` AST node.
+ */
+function visitRest(
+  cursor: TreeCursor,
+  state: EditorState,
+): Rest {
+  cursor.firstChild(); // Step into the RestType
+  let rest: Rest;
+
+  if (cursor.name === "RestInOut") {
+    cursor.firstChild(); // Step into Number
+    const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
+    cursor.parent(); // Back to RestInOut
+    rest = {
+      modifier: InstructionModifiers.REST,
+      type: "InOut",
+      swimmersIn: swimmersIn,
+    }
+  } else if (cursor.name === "RestAfterStop") {
+    cursor.firstChild(); // Step into the Duration
+    const duration = visitDuration(cursor, state);
+    cursor.parent(); // Back to RestAfterStop
+    rest = {
+      modifier: InstructionModifiers.REST,
+      type: "AfterStop",
+      ...duration,
+    }
+  } else {
+    // RestSinceStart
+    cursor.firstChild(); // Step into the Duration
+    const duration = visitDuration(cursor, state);
+    cursor.parent(); // Back to RestSinceStart
+    rest = {
+      modifier: InstructionModifiers.REST,
+      type: "SinceStart",
+      ...duration,
+    }
+  }
+  cursor.parent(); // Back to Rest
+
+  return rest
 }
 
 /**

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -172,6 +172,16 @@ function visitDuration(
   return { minutes, seconds };
 }
 
+function visitInOut(
+  cursor: TreeCursor,
+  state: EditorState,
+): { swimmersIn: string } {
+  cursor.firstChild();
+  const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
+  cursor.parent();
+  return { swimmersIn };
+}
+
 /**
  * Convert the swimDSL equipment name to the swiML equipment name.
  *
@@ -264,25 +274,38 @@ function visitInstructionModifier(
     };
   }
 
-  if (cursor.name === "InOut") {
-    cursor.firstChild();
-    const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
-    cursor.parent();
-
-    return {
-      modifier: InstructionModifiers.IN_OUT,
-      swimmersIn,
-    };
-  }
+  // if (cursor.name === "InOut") {
+  //   cursor.firstChild();
+  //   const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
+  //   cursor.parent();
+  //
+  //   return {
+  //     modifier: InstructionModifiers.IN_OUT,
+  //     swimmersIn,
+  //   };
+  // }
 
   // We are in Duration
   // Get the specified rest keyword
   const getType = state.wordAt(cursor.from - 1);
-  const restType = getType ? state.sliceDoc(getType.from, getType.to) : "";
+  let restType = getType ? state.sliceDoc(getType.from, getType.to) : "";
+  if (restType === "in") restType = "in-out";
+  // // console.log(restType);
+  // const textBefore = state.sliceDoc(0, cursor.from).trimEnd();
+  // // const match = textBefore.match(/(\S+)\s*$/);
+  // const restType = /(\S+)\s*$/.exec(textBefore)?.[1] ?? "";
+  console.log(restType);
+
+  const isDuration = ["on", "rest"];
+  const durationResult = isDuration.includes(restType)
+    ? visitDuration(cursor, state)
+    : visitInOut(cursor, state);
+
   return {
-    modifier: InstructionModifiers.TIME,
+    modifier: InstructionModifiers.REST,
     keyWord: restType,
-    ...visitDuration(cursor, state),
+    ...durationResult,
+
   };
 }
 

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -172,16 +172,6 @@ function visitDuration(
   return { minutes, seconds };
 }
 
-function visitInOut(
-  cursor: TreeCursor,
-  state: EditorState,
-): { swimmersIn: string } {
-  cursor.firstChild();
-  const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
-  cursor.parent();
-  return { swimmersIn };
-}
-
 /**
  * Convert the swimDSL equipment name to the swiML equipment name.
  *
@@ -274,15 +264,16 @@ function visitInstructionModifier(
     };
   }
 
-  // We are in Duration
-  // Get the specified rest keyword
-  const getType = state.wordAt(cursor.from - 1);
-  const restType = getType ? state.sliceDoc(getType.from, getType.to) : "";
-  const isDuration = ["on", "rest"];
-  const durationResult = isDuration.includes(restType)
-    ? visitDuration(cursor, state)
-    : visitInOut(cursor, state);
-
+  // We are in Rest
+  // Get rest type
+  const restType: string = state.sliceDoc(cursor.from, cursor.to).split(" ")[0] ?? "";
+  // Step into first child i.e. Duration(timedRest) or Number(inOut)
+  cursor.firstChild();
+  const durationResult = restType === "in-out"
+    ? { swimmersIn: state.sliceDoc(cursor.from, cursor.to) }
+    : visitDuration(cursor, state);
+  // Step back to Rest
+  cursor.parent();
   return {
     modifier: InstructionModifiers.REST,
     keyWord: restType,

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -297,16 +297,14 @@ function visitRest(
     cursor.firstChild(); // Step into Number
     const swimmersIn = state.sliceDoc(cursor.from, cursor.to);
     cursor.parent(); // Back to RestInOut
+
     rest = {
       modifier: InstructionModifiers.REST,
       type: "InOut",
       swimmersIn: swimmersIn,
     }
   } else {
-    const type =
-      cursor.name === "RestAfterStop"
-        ? "AfterStop"
-        : "SinceStart";
+    const type = cursor.name === "RestAfterStop" ? "AfterStop" : "SinceStart";
 
     cursor.firstChild();
     const duration = visitDuration(cursor, state);

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -302,25 +302,21 @@ function visitRest(
       type: "InOut",
       swimmersIn: swimmersIn,
     }
-  } else if (cursor.name === "RestAfterStop") {
-    cursor.firstChild(); // Step into the Duration
-    const duration = visitDuration(cursor, state);
-    cursor.parent(); // Back to RestAfterStop
-    rest = {
-      modifier: InstructionModifiers.REST,
-      type: "AfterStop",
-      ...duration,
-    }
   } else {
-    // RestSinceStart
-    cursor.firstChild(); // Step into the Duration
+    const type =
+      cursor.name === "RestAfterStop"
+        ? "AfterStop"
+        : "SinceStart";
+
+    cursor.firstChild();
     const duration = visitDuration(cursor, state);
-    cursor.parent(); // Back to RestSinceStart
+    cursor.parent();
+
     rest = {
       modifier: InstructionModifiers.REST,
-      type: "SinceStart",
+      type,
       ...duration,
-    }
+    };
   }
   cursor.parent(); // Back to Rest
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -122,6 +122,27 @@ export function incompatibleEquipmentDiagnostic(
 }
 
 /**
+ * Provide the user with an error message when they attempt to specify multiple rest
+ * times for one swim instruction.
+ *
+ * @param from - The position of the first character to include in the error.
+ * @param to - The position of the last character to include in the error.
+ *
+ * @returns An editor diagnostic for incompatible equipment.
+ */
+export function multipleRestDiagnostic(
+  from: number,
+  to: number,
+): Diagnostic {
+  return {
+    from,
+    to,
+    severity: "error",
+    message: "Multiple rest times specified. Please only specify at most one rest time per instruction.",
+  }
+}
+
+/**
  * Convert a string from "PascalCase" to "sentence case".
  *
  * @param pascalCase - The string written in Pascal case.

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -185,39 +185,30 @@ function lintIncompatibleEquipment(
  * rest durations per instruction.
  *
  * @param node - A reference to a syntax node to lint.
- * @param editorState - The current state of the CodeMirror code editor.
  * @param diagnostics - An array of diagnostics to append to if `node`
  *    detects multiple rest specifications.
  */
 function lintMultipleRest(
   node: SyntaxNodeRef,
-  editorState: EditorState,
   diagnostics: Diagnostic[],
 ): void {
-  if (node.name !== "Duration" && node.name !== "InOut") return;
+  if (node.name !== "Rest") return;
 
   const parent = node.node.parent;
   if (!parent) return;
 
-  const durationNodes: SyntaxNode[] = parent.getChildren("Duration");
-  const inOutNodes: SyntaxNode[] = parent.getChildren("InOut");
-  const allSpecs = [...durationNodes, ...inOutNodes]
-    .sort((a, b) => a.from - b.from);
+  const restSpecifications: SyntaxNode[] = parent.getChildren("Rest");
+  if (restSpecifications.length <= 1) return;
 
-  if (allSpecs.length <= 1) return;
+  // Only push the diagnostic once, when visiting the first Duration
+  if (restSpecifications[0]?.from !== node.from) return;
 
-  // Only push the diagnostic once, when visiting the first node
-  if (allSpecs[0]?.from !== node.from) return;
+  const firstRest = restSpecifications[0];
+  const lastRest = restSpecifications[restSpecifications.length - 1];
 
-  const firstSpec = allSpecs[0];
-  const lastSpec = allSpecs[allSpecs.length - 1];
-
-  if (lastSpec !== undefined) {
-    const prevWord = editorState.wordAt(firstSpec.from - 1);
-    const fromPosition = prevWord ? prevWord.from : firstSpec.from;
-
+  if (lastRest !== undefined) {
     diagnostics.push(
-      multipleRestDiagnostic(fromPosition, lastSpec.to),
+      multipleRestDiagnostic(firstRest.from, lastRest.to),
     );
   }
 }
@@ -349,7 +340,7 @@ function swimdslLintSource(view: EditorView): Diagnostic[] {
       diagnostics,
     );
     lintInvalidDuration(treeCursor, editorState, diagnostics);
-    lintMultipleRest(treeCursor, editorState, diagnostics);
+    lintMultipleRest(treeCursor, diagnostics);
   } while (treeCursor.next());
 
   return diagnostics;

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -194,26 +194,30 @@ function lintMultipleRest(
   editorState: EditorState,
   diagnostics: Diagnostic[],
 ): void {
-  if (node.name !== "Duration") return;
+  if (node.name !== "Duration" && node.name !== "InOut") return;
 
   const parent = node.node.parent;
   if (!parent) return;
 
-  const restSpecifications: SyntaxNode[] = parent.getChildren("Duration");
-  if (restSpecifications.length <= 1) return;
+  const durationNodes: SyntaxNode[] = parent.getChildren("Duration");
+  const inOutNodes: SyntaxNode[] = parent.getChildren("InOut");
+  const allSpecs = [...durationNodes, ...inOutNodes]
+    .sort((a, b) => a.from - b.from);
 
-  // Only push the diagnostic once, when visiting the first Duration
-  if (restSpecifications[0]?.from !== node.from) return;
+  if (allSpecs.length <= 1) return;
 
-  const firstRest = restSpecifications[0];
-  const lastRest = restSpecifications[restSpecifications.length - 1];
+  // Only push the diagnostic once, when visiting the first node
+  if (allSpecs[0]?.from !== node.from) return;
 
-  if (lastRest !== undefined) {
-    const prevWord = editorState.wordAt(firstRest.from - 1);
-    const fromPosition = prevWord ? prevWord.from : firstRest.from;
+  const firstSpec = allSpecs[0];
+  const lastSpec = allSpecs[allSpecs.length - 1];
+
+  if (lastSpec !== undefined) {
+    const prevWord = editorState.wordAt(firstSpec.from - 1);
+    const fromPosition = prevWord ? prevWord.from : firstSpec.from;
 
     diagnostics.push(
-      multipleRestDiagnostic(fromPosition, lastRest.to),
+      multipleRestDiagnostic(fromPosition, lastSpec.to),
     );
   }
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -187,7 +187,7 @@ function lintIncompatibleEquipment(
  * @param node - A reference to a syntax node to lint.
  * @param editorState - The current state of the CodeMirror code editor.
  * @param diagnostics - An array of diagnostics to append to if `node`
- *    specifies a combination of incompatible equipment items.
+ *    detects multiple rest specifications.
  */
 function lintMultipleRest(
   node: SyntaxNodeRef,

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -2,7 +2,7 @@ import { syntaxTree } from "@codemirror/language";
 import { Diagnostic, linter } from "@codemirror/lint";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { SyntaxNodeRef, TreeCursor } from "@lezer/common";
+import { SyntaxNode, SyntaxNodeRef, TreeCursor } from "@lezer/common";
 
 import {
   duplicateEquipmentDiagnostic,
@@ -10,6 +10,7 @@ import {
   incompatibleEquipmentDiagnostic,
   invalidDurationDiagnostic,
   invalidNodeValueDiagnostic,
+  multipleRestDiagnostic,
   syntaxErrorDiagnostic,
   undefinedPaceNameDiagnostic,
 } from "./diagnostics";
@@ -180,6 +181,44 @@ function lintIncompatibleEquipment(
 }
 
 /**
+ * Provide a lint error to the user for attempting to specify multiple
+ * rest durations per instruction.
+ *
+ * @param node - A reference to a syntax node to lint.
+ * @param editorState - The current state of the CodeMirror code editor.
+ * @param diagnostics - An array of diagnostics to append to if `node`
+ *    specifies a combination of incompatible equipment items.
+ */
+function lintMultipleRest(
+  node: SyntaxNodeRef,
+  editorState: EditorState,
+  diagnostics: Diagnostic[],
+): void {
+  if (node.name !== "Duration") return;
+
+  const parent = node.node.parent;
+  if (!parent) return;
+
+  const restSpecifications: SyntaxNode[] = parent.getChildren("Duration");
+  if (restSpecifications.length <= 1) return;
+
+  // Only push the diagnostic once, when visiting the first Duration
+  if (restSpecifications[0]?.from !== node.from) return;
+
+  const firstRest = restSpecifications[0];
+  const lastRest = restSpecifications[restSpecifications.length - 1];
+
+  if (lastRest !== undefined) {
+    const prevWord = editorState.wordAt(firstRest.from - 1);
+    const fromPosition = prevWord ? prevWord.from : firstRest.from;
+
+    diagnostics.push(
+      multipleRestDiagnostic(fromPosition, lastRest.to),
+    );
+  }
+}
+
+/**
  * Provide a lint error to the user for providing an unknown identifier.
  *
  * Examples of providing unknown identifiers could be, specifying a stroke of
@@ -306,6 +345,7 @@ function swimdslLintSource(view: EditorView): Diagnostic[] {
       diagnostics,
     );
     lintInvalidDuration(treeCursor, editorState, diagnostics);
+    lintMultipleRest(treeCursor, editorState, diagnostics);
   } while (treeCursor.next());
 
   return diagnostics;

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -125,6 +125,10 @@ function writeInstructionModifier(
       }
       break;
 
+    case InstructionModifiers.IN_OUT:
+      xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
+      break;
+
     case InstructionModifiers.UNDERWATER:
       xmlParent.ele("underwater").txt(modifier.isTrue.toString());
       break;

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -125,10 +125,6 @@ function writeInstructionModifier(
       }
       break;
 
-    // case InstructionModifiers.IN_OUT:
-    //   xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
-    //   break;
-
     case InstructionModifiers.UNDERWATER:
       xmlParent.ele("underwater").txt(modifier.isTrue.toString());
       break;

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -8,7 +8,6 @@ import {
   Intensity,
   Message,
   Programme,
-  RestInstruction,
   Statements,
   SwimInstruction,
 } from "./astTypes";
@@ -55,9 +54,6 @@ function writeInstruction(
       writeSwimInstruction(xmlParent, instruction);
       break;
 
-    case Statements.REST_INSTRUCTION:
-      writeRestInstruction(xmlParent, instruction);
-      break;
     case Statements.MESSAGE:
       writeMessage(xmlParent, instruction);
       break;
@@ -175,24 +171,6 @@ function writeSwimInstruction(
 }
 
 /**
- * Write an AST RestInstruction node into the XML document.
- *
- * @param xmlParent - The parent XML node to write the rest instruction inside
- *    of.
- * @param instruction - The AST rest instruction node to write as XML.
- */
-function writeRestInstruction(
-  xmlParent: XMLBuilder,
-  instruction: RestInstruction,
-): void {
-  xmlParent
-    .ele("instruction")
-    .ele("rest")
-    .ele("afterStop")
-    .txt(xmlDuration(instruction.minutes, instruction.seconds));
-}
-
-/**
  * Write an AST Message node into the XML document.
  *
  * @param xmlParent - The parent XML node to write the message inside of.
@@ -293,10 +271,6 @@ export default function emitXml(programme: Programme): string {
     switch (statement.statement) {
       case Statements.SWIM_INSTRUCTION:
         writeSwimInstruction(doc, statement);
-        break;
-
-      case Statements.REST_INSTRUCTION:
-        writeRestInstruction(doc, statement);
         break;
 
       case Statements.MESSAGE:

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -108,7 +108,7 @@ function writeInstructionModifier(
 
     case InstructionModifiers.REST:
       if (modifier.minutes && modifier.seconds) {
-        if (modifier.keyWord === "rest") {
+        if (modifier.keyWord === "with") {
           xmlParent
             .ele("rest")
             .ele("afterStop")

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -111,10 +111,18 @@ function writeInstructionModifier(
       break;
 
     case InstructionModifiers.TIME:
-      xmlParent
-        .ele("rest")
-        .ele("sinceStart")
-        .txt(xmlDuration(modifier.minutes, modifier.seconds));
+      if (modifier.keyWord === "rest") {
+        xmlParent
+          .ele("rest")
+          .ele("afterStop")
+          .txt(xmlDuration(modifier.minutes, modifier.seconds));
+      } else {
+        // 'on' restType used
+        xmlParent
+          .ele("rest")
+          .ele("sinceStart")
+          .txt(xmlDuration(modifier.minutes, modifier.seconds));
+      }
       break;
 
     case InstructionModifiers.UNDERWATER:

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -106,24 +106,28 @@ function writeInstructionModifier(
       xmlParent.ele("breath").txt(modifier.breatheStrokes);
       break;
 
-    case InstructionModifiers.TIME:
-      if (modifier.keyWord === "rest") {
-        xmlParent
-          .ele("rest")
-          .ele("afterStop")
-          .txt(xmlDuration(modifier.minutes, modifier.seconds));
-      } else {
-        // 'on' restType used
-        xmlParent
-          .ele("rest")
-          .ele("sinceStart")
-          .txt(xmlDuration(modifier.minutes, modifier.seconds));
+    case InstructionModifiers.REST:
+      if (modifier.minutes && modifier.seconds) {
+        if (modifier.keyWord === "rest") {
+          xmlParent
+            .ele("rest")
+            .ele("afterStop")
+            .txt(xmlDuration(modifier.minutes, modifier.seconds));
+        } else {
+          // 'on' restType used
+          xmlParent
+            .ele("rest")
+            .ele("sinceStart")
+            .txt(xmlDuration(modifier.minutes, modifier.seconds));
+        }
+      } else if (modifier.swimmersIn) {
+        xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
       }
       break;
 
-    case InstructionModifiers.IN_OUT:
-      xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
-      break;
+    // case InstructionModifiers.IN_OUT:
+    //   xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
+    //   break;
 
     case InstructionModifiers.UNDERWATER:
       xmlParent.ele("underwater").txt(modifier.isTrue.toString());

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -107,21 +107,16 @@ function writeInstructionModifier(
       break;
 
     case InstructionModifiers.REST:
-      if (modifier.minutes && modifier.seconds) {
-        if (modifier.keyWord === "with") {
-          xmlParent
-            .ele("rest")
-            .ele("afterStop")
-            .txt(xmlDuration(modifier.minutes, modifier.seconds));
-        } else {
-          // 'on' restType used
-          xmlParent
-            .ele("rest")
-            .ele("sinceStart")
-            .txt(xmlDuration(modifier.minutes, modifier.seconds));
-        }
-      } else if (modifier.swimmersIn) {
-        xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
+      switch (modifier.type) {
+        case "SinceStart":
+          xmlParent.ele("rest").ele("sinceStart").txt(xmlDuration(modifier.minutes, modifier.seconds));
+          break;
+        case "AfterStop":
+          xmlParent.ele("rest").ele("afterStop").txt(xmlDuration(modifier.minutes, modifier.seconds));
+          break;
+        case "InOut":
+          xmlParent.ele("rest").ele("inOut").txt(modifier.swimmersIn);
+          break;
       }
       break;
 

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -101,7 +101,7 @@ paceSpecification {
 }
 
 timeSpecification {
-    onKeyword Duration
+    (onKeyword | restKeyword) Duration
 }
 
 Duration {
@@ -142,6 +142,7 @@ messageSpecification {
     @precedence { Comment, Message }
     @precedence { underwaterKeyword, identifier }
     @precedence { breatheKeyword, identifier }
+    @precedence { restKeyword, identifier }
 }
 
 @skip { space | Comment }

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -84,6 +84,7 @@ instructionModifier {
     | timeSpecification
     | Underwater
     | Breathe
+    | InOut
 }
 
 Breathe {
@@ -98,6 +99,10 @@ EquipmentName { identifier }
 
 paceSpecification {
     "@" Pace
+}
+
+InOut {
+    inOutKeyword Number
 }
 
 timeSpecification {
@@ -124,6 +129,7 @@ messageSpecification {
     onKeyword             { "on" }
     underwaterKeyword     { "Underwater" }
     breatheKeyword        { "breathe" }
+    inOutKeyword          { "in-out" }
     space       { @whitespace+ }
     Comment     { "#" ![\n]* }
     Number      { @digit+ }
@@ -143,6 +149,7 @@ messageSpecification {
     @precedence { underwaterKeyword, identifier }
     @precedence { breatheKeyword, identifier }
     @precedence { restKeyword, identifier }
+    @precedence { inOutKeyword, identifier }
 }
 
 @skip { space | Comment }

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -51,7 +51,6 @@ statement {
 
 instruction {
     SwimInstruction
-    | RestInstruction
     | messageSpecification
 }
 
@@ -111,10 +110,6 @@ timeSpecification {
 
 Duration {
     Number ":" Number    // minutes:seconds
-}
-
-RestInstruction {
-    Duration restKeyword
 }
 
 messageSpecification {

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -118,7 +118,7 @@ inOut {
 }
 
 timedRest {
-    (onKeyword | restKeyword) Duration
+    (onKeyword | withKeyword) Duration
 }
 
 Duration {
@@ -133,7 +133,7 @@ messageSpecification {
     setKeyword            { "set" }
     authorKeyword         { "author" }
     paceKeyword           { "pace" }
-    restKeyword           { "rest" }
+    withKeyword           { "with" }
     onKeyword             { "on" }
     underwaterKeyword     { "underwater" }
     breatheKeyword        { "breathe" }
@@ -159,7 +159,7 @@ messageSpecification {
     @precedence { excludeAlignKeyword, Message }
     @precedence { underwaterKeyword, identifier }
     @precedence { breatheKeyword, identifier }
-    @precedence { restKeyword, identifier }
+    @precedence { withKeyword, identifier }
     @precedence { inOutKeyword, identifier }
 }
 

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -80,11 +80,14 @@ Underwater {
 instructionModifier {
     EquipmentSpecification
     | paceSpecification
-    | timeSpecification
+    | Rest
     | Underwater
     | Breathe
-    | InOut
     | InstructionDescription
+}
+
+Rest {
+    timedRest | inOut
 }
 
 InstructionDescription {
@@ -105,11 +108,11 @@ paceSpecification {
     "@" Pace
 }
 
-InOut {
+inOut {
     inOutKeyword Number
 }
 
-timeSpecification {
+timedRest {
     (onKeyword | restKeyword) Duration
 }
 
@@ -127,7 +130,7 @@ messageSpecification {
     paceKeyword           { "pace" }
     restKeyword           { "rest" }
     onKeyword             { "on" }
-    underwaterKeyword     { "Underwater" }
+    underwaterKeyword     { "underwater" }
     breatheKeyword        { "breathe" }
     inOutKeyword          { "in-out" }
     space       { @whitespace+ }

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -92,7 +92,19 @@ ExcludeAlignSpecification {
 }
 
 Rest {
-    timedRest | inOut
+    RestSinceStart | RestAfterStop | RestInOut
+}
+
+RestSinceStart {
+    onKeyword Duration
+}
+
+RestAfterStop {
+    withKeyword Duration
+}
+
+RestInOut {
+    inOutKeyword Number
 }
 
 InstructionDescription {
@@ -111,14 +123,6 @@ EquipmentName { identifier }
 
 paceSpecification {
     "@" Pace
-}
-
-inOut {
-    inOutKeyword Number
-}
-
-timedRest {
-    (onKeyword | withKeyword) Duration
 }
 
 Duration {

--- a/test/cases.lezertest
+++ b/test/cases.lezertest
@@ -169,18 +169,18 @@ SwimProgramme(PaceDefinition(PaceDefinitionName, Pace(Number, Number)))
 
 SwimProgramme(SwimInstruction(
   SingleInstruction(Number, Stroke),
-  Duration(Number, Number)))
+  Rest(Duration(Number, Number))))
 
 
 ## Rest instruction
 
-100 Freestyle rest 1:00
+100 Freestyle with 1:00
 
 ==>
 
 SwimProgramme(SwimInstruction(
   SingleInstruction(Number, Stroke),
-  Duration(Number, Number)))
+  Rest(Duration(Number, Number))))
 
 
 ## Repeated single instruction
@@ -203,7 +203,7 @@ SwimProgramme(SwimInstruction(
 SwimProgramme(SwimInstruction(
   Number,
   SingleInstruction(Number, Stroke),
-  Duration(Number, Number)))
+  Rest(Duration(Number, Number))))
 
 
 ## Repeated single instruction with intensity
@@ -275,7 +275,7 @@ SwimProgramme(SwimInstruction(
     SwimInstruction(SingleInstruction(Number, Stroke)),
     SwimInstruction(SingleInstruction(Number, Stroke)),
     SwimInstruction(SingleInstruction(Number, Stroke))),
-  Duration(Number, Number)))
+  Rest(Duration(Number, Number))))
 
 
 ## Repeated block instruction
@@ -298,7 +298,7 @@ SwimProgramme(SwimInstruction(
 
 2 x {
   50 Backstroke
-  100 Freestyle rest 0:30
+  100 Freestyle with 0:30
 } Pull + PullBuoy @ 70%
 
 ==>
@@ -307,7 +307,7 @@ SwimProgramme(SwimInstruction(
   Number,
   BlockInstruction(
     SwimInstruction(SingleInstruction(Number, Stroke)),
-    SwimInstruction(SingleInstruction(Number, Stroke),Duration(Number,Number))),
+    SwimInstruction(SingleInstruction(Number, Stroke),Rest(Duration(Number,Number)))),
   StrokeModifier,
   EquipmentSpecification(EquipmentName),
   Pace(Number)))
@@ -412,7 +412,7 @@ SwimProgramme(SwimInstruction(
   StrokeModifier,
   EquipmentSpecification(EquipmentName, EquipmentName),
   Pace(Number, Number),
-  Duration(Number, Number)))
+  Rest(Duration(Number, Number))))
 
 
 ## Full Programme Structure
@@ -444,7 +444,7 @@ SwimProgramme(
   SwimInstruction(
     Number,
     SingleInstruction(Number, Stroke),
-    Duration(Number, Number)))
+    Rest(Duration(Number, Number))))
 
 
 ## Multiple Block instructions
@@ -485,4 +485,16 @@ SwimProgramme(SwimInstruction(
       SingleInstruction(Number, Stroke),
       StrokeModifier,
       EquipmentSpecification(EquipmentName),
-      Duration(Number, Number)))))
+      Rest(Duration(Number, Number))))))
+
+
+## Instruction with in-out rest
+
+100 Butterfly in-out 3
+
+==>
+
+SwimProgramme(
+    SwimInstruction(
+        SingleInstruction(Number, Stroke),
+        Rest(Number)))

--- a/test/cases.lezertest
+++ b/test/cases.lezertest
@@ -307,7 +307,7 @@ SwimProgramme(SwimInstruction(
   Number,
   BlockInstruction(
     SwimInstruction(SingleInstruction(Number, Stroke)),
-    SwimInstruction(SingleInstruction(Number, Stroke),Duration(Number,Number)),
+    SwimInstruction(SingleInstruction(Number, Stroke),Duration(Number,Number))),
   StrokeModifier,
   EquipmentSpecification(EquipmentName),
   Pace(Number)))

--- a/test/cases.lezertest
+++ b/test/cases.lezertest
@@ -169,7 +169,7 @@ SwimProgramme(PaceDefinition(PaceDefinitionName, Pace(Number, Number)))
 
 SwimProgramme(SwimInstruction(
   SingleInstruction(Number, Stroke),
-  Rest(Duration(Number, Number))))
+  Rest(RestSinceStart(Duration(Number, Number)))))
 
 
 ## Rest instruction
@@ -180,7 +180,7 @@ SwimProgramme(SwimInstruction(
 
 SwimProgramme(SwimInstruction(
   SingleInstruction(Number, Stroke),
-  Rest(Duration(Number, Number))))
+  Rest(RestAfterStop(Duration(Number, Number)))))
 
 
 ## Repeated single instruction
@@ -203,7 +203,7 @@ SwimProgramme(SwimInstruction(
 SwimProgramme(SwimInstruction(
   Number,
   SingleInstruction(Number, Stroke),
-  Rest(Duration(Number, Number))))
+  Rest(RestSinceStart(Duration(Number, Number)))))
 
 
 ## Repeated single instruction with intensity
@@ -275,7 +275,7 @@ SwimProgramme(SwimInstruction(
     SwimInstruction(SingleInstruction(Number, Stroke)),
     SwimInstruction(SingleInstruction(Number, Stroke)),
     SwimInstruction(SingleInstruction(Number, Stroke))),
-  Rest(Duration(Number, Number))))
+  Rest(RestSinceStart(Duration(Number, Number)))))
 
 
 ## Repeated block instruction
@@ -307,7 +307,7 @@ SwimProgramme(SwimInstruction(
   Number,
   BlockInstruction(
     SwimInstruction(SingleInstruction(Number, Stroke)),
-    SwimInstruction(SingleInstruction(Number, Stroke),Rest(Duration(Number,Number)))),
+    SwimInstruction(SingleInstruction(Number, Stroke),Rest(RestAfterStop(Duration(Number,Number))))),
   StrokeModifier,
   EquipmentSpecification(EquipmentName),
   Pace(Number)))
@@ -412,7 +412,7 @@ SwimProgramme(SwimInstruction(
   StrokeModifier,
   EquipmentSpecification(EquipmentName, EquipmentName),
   Pace(Number, Number),
-  Rest(Duration(Number, Number))))
+  Rest(RestSinceStart(Duration(Number, Number)))))
 
 
 ## Full Programme Structure
@@ -444,7 +444,7 @@ SwimProgramme(
   SwimInstruction(
     Number,
     SingleInstruction(Number, Stroke),
-    Rest(Duration(Number, Number))))
+    Rest(RestSinceStart(Duration(Number, Number)))))
 
 
 ## Multiple Block instructions
@@ -485,7 +485,7 @@ SwimProgramme(SwimInstruction(
       SingleInstruction(Number, Stroke),
       StrokeModifier,
       EquipmentSpecification(EquipmentName),
-      Rest(Duration(Number, Number))))))
+      Rest(RestSinceStart(Duration(Number, Number)))))))
 
 
 ## Instruction with in-out rest
@@ -497,4 +497,4 @@ SwimProgramme(SwimInstruction(
 SwimProgramme(
     SwimInstruction(
         SingleInstruction(Number, Stroke),
-        Rest(Number)))
+        Rest(RestInOut(Number))))

--- a/test/cases.lezertest
+++ b/test/cases.lezertest
@@ -174,25 +174,13 @@ SwimProgramme(SwimInstruction(
 
 ## Rest instruction
 
-1:00 rest
+100 Freestyle rest 1:00
 
 ==>
 
-SwimProgramme(RestInstruction(Duration(Number, Number)))
-
-
-## Multiple rest instructions
-
-1:00 rest
-0:30 rest
-0:15 rest
-
-==>
-
-SwimProgramme(
-  RestInstruction(Duration(Number, Number)),
-  RestInstruction(Duration(Number, Number)),
-  RestInstruction(Duration(Number, Number)))
+SwimProgramme(SwimInstruction(
+  SingleInstruction(Number, Stroke),
+  Duration(Number, Number)))
 
 
 ## Repeated single instruction
@@ -310,8 +298,7 @@ SwimProgramme(SwimInstruction(
 
 2 x {
   50 Backstroke
-  100 Freestyle
-  0:30 rest
+  100 Freestyle rest 0:30
 } Pull + PullBuoy @ 70%
 
 ==>
@@ -320,8 +307,7 @@ SwimProgramme(SwimInstruction(
   Number,
   BlockInstruction(
     SwimInstruction(SingleInstruction(Number, Stroke)),
-    SwimInstruction(SingleInstruction(Number, Stroke)),
-    RestInstruction(Duration(Number, Number))),
+    SwimInstruction(SingleInstruction(Number, Stroke),Duration(Number,Number)),
   StrokeModifier,
   EquipmentSpecification(EquipmentName),
   Pace(Number)))
@@ -442,7 +428,6 @@ pace hard = 90%
 
 > Main Set
 4 x 100 Backstroke on 1:30
-0:30 rest
 
 ==>
 
@@ -459,8 +444,7 @@ SwimProgramme(
   SwimInstruction(
     Number,
     SingleInstruction(Number, Stroke),
-    Duration(Number, Number)),
-  RestInstruction(Duration(Number, Number)))
+    Duration(Number, Number)))
 
 
 ## Multiple Block instructions
@@ -485,7 +469,6 @@ SwimProgramme(
   > Round
   100 Freestyle @ 60%
   4 x 25 Backstroke Kick + Fins on 0:30
-  0:30 rest
 }
 
 ==>
@@ -502,5 +485,4 @@ SwimProgramme(SwimInstruction(
       SingleInstruction(Number, Stroke),
       StrokeModifier,
       EquipmentSpecification(EquipmentName),
-      Duration(Number, Number)),
-    RestInstruction(Duration(Number, Number)))))
+      Duration(Number, Number)))))


### PR DESCRIPTION
Implemented the "afterStop" with and "inOut" with rest instruction types such that they match the swiML schema.  These can be modeled with  `[Distance] [Stroke] rest [Duration]` and `[Distance] [Stroke] in-out [Number of Swimmers]`
Added linting for multiple specifications of rest in a single instruction. \
Removed previous `rest [Duration]` implementation.

<img width="1245" height="303" alt="image" src="https://github.com/user-attachments/assets/849b6b0e-fca6-4f9d-8298-114a8ea118d4" />


Unsure on what "sinceLastRest" represents, have implemented in a separate branch but will get Christoph's input on it first

Closes #2 