### PR TITLE
Adding string values to AST type enums

### DIFF
--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -1,20 +1,20 @@
 export const enum Statements {
-  SWIM_INSTRUCTION,
-  REST_INSTRUCTION,
-  MESSAGE,
-  PACE_DEFINITION,
-  CONSTANT_DEFINITION,
-  AUTHOR_DEFINITION,
+  SWIM_INSTRUCTION = "SwimInstruction",
+  REST_INSTRUCTION = "RestInstruction",
+  MESSAGE = "Message",
+  PACE_DEFINITION = "PaceDefinition",
+  CONSTANT_DEFINITION = "ConstantDefinition",
+  AUTHOR_DEFINITION = "AuthorDefintion",
 }
 
 export const enum InstructionModifiers {
-  EQUIPMENT_SPECIFICATION,
-  PACE,
-  TIME,
-  EXCLUDE_ALIGN,
-  BREATHE,
-  UNDERWATER,
-  INSTRUCTION_DESCRIPTION,
+  EQUIPMENT_SPECIFICATION = "EquipmentSpecification",
+  PACE = "Pace",
+  TIME = "Time",
+  EXCLUDE_ALIGN = "ExcludeAlignSpecification",
+  BREATHE = "Breathe",
+  UNDERWATER = "Underwater",
+  INSTRUCTION_DESCRIPTION = "InstructionDescription",
 }
 
 export interface ExcludeAlign {

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -631,9 +631,9 @@ export default function buildAst(
 
   function walk(): void {
     do {
-      let node: Statement;
+      let node: Statement | null = null;
 
-      switch (cursor.type.name as Statements) {
+      switch (cursor.type.name as Statements | "") {
         case Statements.SWIM_INSTRUCTION:
           node = visitSwimInstruction(cursor, state);
           break;
@@ -654,7 +654,9 @@ export default function buildAst(
           break;
       }
 
-      statements.push(node);
+      if (node !== null) {
+        statements.push(node);
+      }
     } while (cursor.nextSibling());
   }
 

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -631,34 +631,30 @@ export default function buildAst(
 
   function walk(): void {
     do {
-      let node: Statement | null = null;
+      let node: Statement;
 
-      switch (cursor.type.name) {
-        case "SwimInstruction":
+      switch (cursor.type.name as Statements) {
+        case Statements.SWIM_INSTRUCTION:
           node = visitSwimInstruction(cursor, state);
           break;
-        case "RestInstruction":
+        case Statements.REST_INSTRUCTION:
           node = visitRestInstruction(cursor, state);
           break;
-        case "Message":
+        case Statements.MESSAGE:
           node = visitMessage(cursor, state);
           break;
-        case "PaceDefinition":
+        case Statements.PACE_DEFINITION:
           node = visitPaceDefinition(cursor, state);
           break;
-        case "ConstantDefinition":
+        case Statements.CONSTANT_DEFINITION:
           node = visitConstantDefinition(cursor, state);
           break;
-        case "AuthorDefinition":
+        case Statements.AUTHOR_DEFINITION:
           node = visitAuthorDefinition(cursor, state);
-          break;
-        default:
           break;
       }
 
-      if (node !== null) {
-        statements.push(node);
-      }
+      statements.push(node);
     } while (cursor.nextSibling());
   }
 


### PR DESCRIPTION
I was debugging the bug in earlier versions of #42 and found the integer statement and instruction modifier values very unhelpful. This change makes the values immediately useful without having to look at the order of the items in the enum definition.

It also has the cool outcome of making the `buildAst` function not directly depend on the string names of the syntax nodes. This responsibility now lies in the `astTypes` module, which makes sense in terms of cohesion/coupling.

- **refactor(ast-types): Added syntax node names as string values to ast type enums**
- **refactor(build-ast): Changed buildAst function to use new string enum values**
- **fix(build-ast): Put back null state in buildAst as it prevents a bug when the editor is empty**
