### PR TITLE
fix(repetitions): Fixed repetitions not rendering for single instructions and single block instructions

### DIFF
--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -151,18 +151,25 @@ function writeSwimInstruction(
   xmlParent: XMLBuilder,
   instruction: SwimInstruction,
 ): void {
-  let parent = xmlParent.ele("instruction");
+  let parent = xmlParent;
 
   if (instruction.repetitions > 1) {
+    parent = xmlParent.ele("instruction");
     parent = parent.ele("repetition");
-    parent.ele("repetitionCount").txt(String(instruction.repetitions)).up();
+    parent.ele("repetitionCount").txt(String(instruction.repetitions));
   }
 
   if (instruction.instruction.isBlock) {
+    if (instruction.repetitions <= 1) {
+      parent = xmlParent.ele("instruction");
+      parent = parent.ele("repetition");
+      parent.ele("repetitionCount").txt("1");
+    }
     for (const subInstruction of instruction.instruction.instructions) {
       writeInstruction(parent, subInstruction);
     }
   } else {
+    parent = parent.ele("instruction");
     const len = instruction.instruction.length;
     const length = parent.ele("length");
     if (len.kind === "distance") {


### PR DESCRIPTION
Came across this issue when implementing simplification repetitions and wasn't too difficult to fix.

Fixed an issue where if a repetition was specified for single instructions then the instruction would not be added to the XML correctly and then not render on the swiML image. 
Also fixed the issue where BlockInstructions without a specified rep number should be rendered with a repetition count of 1 but were not

<img width="1232" height="309" alt="image" src="https://github.com/user-attachments/assets/60c8e8f1-4a19-4643-9fcf-9ea0d17f0913" />

Closes #56 #5 