### PR TITLE
feat(simplification-repetitions): Added ability to model simplified repetitions

### DIFF
--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -130,17 +130,6 @@ export interface SimplificationBlock {
   instructions: SwimInstruction[];
 }
 
-export interface SimpleRepetitionInstruction {
-  instruction: SimpleRepetition;
-  strokeModifier?: StrokeModifiers | undefined;
-  instructionModifiers: InstructionModifier[];
-}
-
-export interface SimpleRepetition {
-  repetitions: number;
-  stroke: string;
-}
-
 export interface Intensity {
   isAlias: boolean;
   value: string;

--- a/src/astTypes.ts
+++ b/src/astTypes.ts
@@ -101,7 +101,7 @@ export type InstructionModifier =
 export interface SwimInstruction {
   statement: Statements.SWIM_INSTRUCTION;
   repetitions: number;
-  instruction: SingleInstruction | BlockInstruction;
+  instruction: SingleInstruction | BlockInstruction | SimplificationBlock;
   strokeModifier?: StrokeModifiers | undefined;
   instructionModifiers: InstructionModifier[];
 }
@@ -119,7 +119,26 @@ export interface SingleInstruction {
 
 export interface BlockInstruction {
   isBlock: true;
+  isSimplification: false;
   instructions: Instruction[];
+}
+
+export interface SimplificationBlock {
+  isBlock: true;
+  isSimplification: true;
+  distance: string;
+  instructions: SwimInstruction[];
+}
+
+export interface SimpleRepetitionInstruction {
+  instruction: SimpleRepetition;
+  strokeModifier?: StrokeModifiers | undefined;
+  instructionModifiers: InstructionModifier[];
+}
+
+export interface SimpleRepetition {
+  repetitions: number;
+  stroke: string;
 }
 
 export interface Intensity {

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -1,5 +1,5 @@
-import {EditorState} from "@codemirror/state";
-import {TreeCursor} from "@lezer/common";
+import { EditorState } from "@codemirror/state";
+import { TreeCursor } from "@lezer/common";
 import {
   AuthorDefintion,
   BlockInstruction,
@@ -426,6 +426,19 @@ function getStrokeModifier(strokeModifierName: string): StrokeModifiers {
   }
 }
 
+/**
+ * Create an AST node for a `SimplificationBlock` CST node.
+ * Precondition: `cursor` points to a `SimplificationBlock` node.
+ *
+ * Postcondition: `cursor` will point to the same node it pointed to when
+ * passed to this function.
+ *
+ * @param cursor - A reference to a Lezer syntax tree node.
+ * @param state - The state of the CodeMirror editor.
+ * @param distance - The distance of the repetitions in the block.
+ *
+ * @returns A `SwimInstruction` AST node.
+ */
 function visitSimpleRepetition(
   cursor: TreeCursor,
   state: EditorState,
@@ -465,7 +478,7 @@ function visitSimpleRepetition(
     instruction: {isBlock: false, length: { kind: "distance", value: distance}, stroke},
     strokeModifier,
     instructionModifiers,
-  }
+  };
 }
 
 /**
@@ -510,7 +523,7 @@ function visitSwimInstruction(
       instructions.push(visitSimpleRepetition(cursor, state, distance));
     } while (cursor.nextSibling());
 
-    instruction = {isBlock:true, isSimplification:true, distance, instructions}
+    instruction = {isBlock:true, isSimplification:true, distance, instructions};
   }
   else if (cursor.name === "BlockInstruction") {
     // Move into first Instruction of the block

--- a/src/buildAst.ts
+++ b/src/buildAst.ts
@@ -1,5 +1,5 @@
-import { EditorState } from "@codemirror/state";
-import { TreeCursor } from "@lezer/common";
+import {EditorState} from "@codemirror/state";
+import {TreeCursor} from "@lezer/common";
 import {
   AuthorDefintion,
   BlockInstruction,
@@ -16,6 +16,7 @@ import {
   PaceDefinition,
   Programme,
   Rest,
+  SimplificationBlock,
   SingleInstruction,
   Statement,
   Statements,
@@ -425,6 +426,48 @@ function getStrokeModifier(strokeModifierName: string): StrokeModifiers {
   }
 }
 
+function visitSimpleRepetition(
+  cursor: TreeCursor,
+  state: EditorState,
+  distance: string,
+): SwimInstruction {
+  let strokeModifier: StrokeModifiers = StrokeModifiers.STANDARD;
+  const instructionModifiers: InstructionModifier[] = [];
+
+  cursor.firstChild();
+  const repetitions = Number(state.sliceDoc(cursor.from, cursor.to));
+  cursor.nextSibling();
+  const stroke = getStroke(state.sliceDoc(cursor.from, cursor.to));
+
+  if (cursor.nextSibling()) {
+    let hasModifiers = true;
+    if (cursor.name === "StrokeModifier") {
+      strokeModifier = getStrokeModifier(
+        state.sliceDoc(cursor.from, cursor.to),
+      );
+
+      // Move away from the StrokeModifier to a potential instruction modifier.
+      hasModifiers = cursor.nextSibling();
+    }
+
+    if (hasModifiers) {
+      do {
+        instructionModifiers.push(visitInstructionModifier(cursor, state));
+      } while (cursor.nextSibling());
+    }
+  }
+
+  // Move up out of the SwimInstruction
+  cursor.parent();
+  return {
+    statement: Statements.SWIM_INSTRUCTION,
+    repetitions,
+    instruction: {isBlock: false, length: { kind: "distance", value: distance}, stroke},
+    strokeModifier,
+    instructionModifiers,
+  }
+}
+
 /**
  * Create an AST node for a `SwimInstruction` CST node.
  *
@@ -444,7 +487,7 @@ function visitSwimInstruction(
 ): SwimInstruction {
   let repetitions = 1;
   let strokeModifier: StrokeModifiers = StrokeModifiers.STANDARD;
-  let instruction: SingleInstruction | BlockInstruction;
+  let instruction: SingleInstruction | BlockInstruction | SimplificationBlock;
   const instructionModifiers: InstructionModifier[] = [];
 
   // Move into either Number (for repetitions) or SingleInstruction |
@@ -458,7 +501,18 @@ function visitSwimInstruction(
     cursor.nextSibling();
   }
 
-  if (cursor.name === "BlockInstruction") {
+  if (cursor.name === "SimplificationBlock") {
+    cursor.firstChild(); // Number
+    const distance = state.sliceDoc(cursor.from, cursor.to);
+    const instructions: SwimInstruction[] = [];
+    cursor.nextSibling();
+    do {
+      instructions.push(visitSimpleRepetition(cursor, state, distance));
+    } while (cursor.nextSibling());
+
+    instruction = {isBlock:true, isSimplification:true, distance, instructions}
+  }
+  else if (cursor.name === "BlockInstruction") {
     // Move into first Instruction of the block
     cursor.firstChild();
 
@@ -467,7 +521,7 @@ function visitSwimInstruction(
       instructions.push(visitInstruction(cursor, state));
     } while (cursor.nextSibling());
 
-    instruction = { isBlock: true, instructions };
+    instruction = { isBlock: true, isSimplification: false, instructions };
     // cursor is still on the last instruction of the block
   } else {
     // cursor is on SingleInstruction

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -186,11 +186,12 @@ function writeSwimInstruction(
   xmlParent: XMLBuilder,
   instruction: SwimInstruction,
 ): void {
-  let parent = xmlParent.ele("instruction");
+  let parent = xmlParent;
 
   if (instruction.repetitions > 1) {
+    parent = xmlParent.ele("instruction");
     parent = parent.ele("repetition");
-    parent.ele("repetitionCount").txt(String(instruction.repetitions)).up();
+    parent.ele("repetitionCount").txt(String(instruction.repetitions));
   }
 
   if (instruction.instruction.isBlock) {
@@ -199,6 +200,7 @@ function writeSwimInstruction(
         writeInstruction(parent, subInstruction);
       }
     } else {
+      parent = parent.ele("instruction");
       parent = parent.ele("repetition");
       parent.ele("repetitionCount").txt("1").up();
       parent.ele("simplify").txt("true").up();

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -142,50 +142,6 @@ function writeInstructionModifier(
 }
 
 /**
- * Write an AST SwimInstruction node in the form of the simplified
- * repetitions to the XML document.
- *
- * @param xmlParent - The parent XML node to write the instruction inside.
- * @param instruction - The AST swim instruction node to write as XML.
- */
-function writeSimpleInstruction(
-  xmlParent: XMLBuilder,
-  instruction: SwimInstruction,
-): void {
-  let parent = xmlParent.ele("instruction").ele("repetition");
-  parent.ele("repetitionCount").txt(instruction.repetitions.toString());
-  parent = parent.ele("instruction");
-
-  if (!instruction.instruction.isBlock) {
-    if (instruction.instruction.length.kind === "distance") {
-      parent
-        .ele("length")
-        .ele("lengthAsDistance")
-        .txt(instruction.instruction.length.value);
-    }
-
-    if (instruction.strokeModifier === StrokeModifiers.KICK) {
-      parent
-        .ele("stroke")
-        .ele("kicking")
-        .ele("standardKick")
-        .txt(instruction.instruction.stroke);
-    } else {
-      parent
-        .ele("stroke")
-        .ele("standardStroke")
-        .txt(instruction.instruction.stroke);
-    }
-  }
-
-  if (instruction.instructionModifiers.length > 0) {
-    for (const modifier of instruction.instructionModifiers) {
-      writeInstructionModifier(parent, modifier);
-    }
-  }
-}
-
-/**
  * Write an AST SwimInstruction node into the XML document.
  *
  * @param xmlParent - The parent XML node to write the instruction inside of.
@@ -214,7 +170,7 @@ function writeSwimInstruction(
       parent.ele("repetitionCount").txt("1").up();
       parent.ele("simplify").txt("true").up();
       for (const subInstructiuon of instruction.instruction.instructions) {
-        writeSimpleInstruction(parent, subInstructiuon);
+        writeSwimInstruction(parent, subInstructiuon);
       }
     }
   } else {

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -141,6 +141,13 @@ function writeInstructionModifier(
   }
 }
 
+/**
+ * Write an AST SwimInstruction node in the form of the simplified
+ * repetitions to the XML document.
+ *
+ * @param xmlParent - The parent XML node to write the instruction inside.
+ * @param instruction - The AST swim instruction node to write as XML.
+ */
 function writeSimpleInstruction(
   xmlParent: XMLBuilder,
   instruction: SwimInstruction,
@@ -150,10 +157,13 @@ function writeSimpleInstruction(
   parent = parent.ele("instruction");
 
   if (!instruction.instruction.isBlock) {
-    if (instruction.instruction.length.kind === "distance")
-    {
-      parent.ele("length").ele("lengthAsDistance").txt(instruction.instruction.length.value);
+    if (instruction.instruction.length.kind === "distance") {
+      parent
+        .ele("length")
+        .ele("lengthAsDistance")
+        .txt(instruction.instruction.length.value);
     }
+
     if (instruction.strokeModifier === StrokeModifiers.KICK) {
       parent
         .ele("stroke")
@@ -174,7 +184,6 @@ function writeSimpleInstruction(
     }
   }
 }
-
 
 /**
  * Write an AST SwimInstruction node into the XML document.
@@ -208,8 +217,8 @@ function writeSwimInstruction(
         writeSimpleInstruction(parent, subInstructiuon);
       }
     }
-
   } else {
+    parent = parent.ele("instruction");
     const len = instruction.instruction.length;
     const length = parent.ele("length");
     if (len.kind === "distance") {

--- a/src/swimlGen.ts
+++ b/src/swimlGen.ts
@@ -141,6 +141,41 @@ function writeInstructionModifier(
   }
 }
 
+function writeSimpleInstruction(
+  xmlParent: XMLBuilder,
+  instruction: SwimInstruction,
+): void {
+  let parent = xmlParent.ele("instruction").ele("repetition");
+  parent.ele("repetitionCount").txt(instruction.repetitions.toString());
+  parent = parent.ele("instruction");
+
+  if (!instruction.instruction.isBlock) {
+    if (instruction.instruction.length.kind === "distance")
+    {
+      parent.ele("length").ele("lengthAsDistance").txt(instruction.instruction.length.value);
+    }
+    if (instruction.strokeModifier === StrokeModifiers.KICK) {
+      parent
+        .ele("stroke")
+        .ele("kicking")
+        .ele("standardKick")
+        .txt(instruction.instruction.stroke);
+    } else {
+      parent
+        .ele("stroke")
+        .ele("standardStroke")
+        .txt(instruction.instruction.stroke);
+    }
+  }
+
+  if (instruction.instructionModifiers.length > 0) {
+    for (const modifier of instruction.instructionModifiers) {
+      writeInstructionModifier(parent, modifier);
+    }
+  }
+}
+
+
 /**
  * Write an AST SwimInstruction node into the XML document.
  *
@@ -159,9 +194,19 @@ function writeSwimInstruction(
   }
 
   if (instruction.instruction.isBlock) {
-    for (const subInstruction of instruction.instruction.instructions) {
-      writeInstruction(parent, subInstruction);
+    if (!instruction.instruction.isSimplification) {
+      for (const subInstruction of instruction.instruction.instructions) {
+        writeInstruction(parent, subInstruction);
+      }
+    } else {
+      parent = parent.ele("repetition");
+      parent.ele("repetitionCount").txt("1").up();
+      parent.ele("simplify").txt("true").up();
+      for (const subInstructiuon of instruction.instruction.instructions) {
+        writeSimpleInstruction(parent, subInstructiuon);
+      }
     }
+
   } else {
     const len = instruction.instruction.length;
     const length = parent.ele("length");

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -56,11 +56,20 @@ instruction {
 
 SwimInstruction {
     (Number repititionOperator)?
-    (SingleInstruction | BlockInstruction) StrokeModifier? instructionModifier*
+    (SingleInstruction | BlockInstruction | SimplificationBlock) StrokeModifier? instructionModifier*
 }
 
 SingleInstruction {
     Length Stroke
+}
+
+SimplificationBlock {
+    LengthAsDistance "{" SimpleRepetition+ "}"
+}
+
+SimpleRepetition {
+    Number
+    Stroke StrokeModifier? instructionModifier*
 }
 
 Length {

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -69,7 +69,7 @@ SimplificationBlock {
 }
 
 SimpleRepetition {
-    (Number)
+    Number
     Stroke StrokeModifier? instructionModifier*
 }
 

--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -64,11 +64,12 @@ SingleInstruction {
 }
 
 SimplificationBlock {
-    LengthAsDistance "{" SimpleRepetition+ "}"
+    (LengthAsDistance simpleRepetitionOperator)
+     "{" SimpleRepetition+ "}"
 }
 
 SimpleRepetition {
-    Number
+    (Number)
     Stroke StrokeModifier? instructionModifier*
 }
 
@@ -168,11 +169,13 @@ messageSpecification {
     StringContent { (!["\\] | "\\" _)+ }
     identifier  { @asciiLetter+ }
     repititionOperator { "x" }
+    simpleRepetitionOperator { "s" }
     lapsKeyword { "laps" | "lap" }
     excludeAlignKeyword { "noalign" }
     @precedence { StringContent, space }
     @precedence { StringContent, Comment }
     @precedence { repititionOperator, identifier }
+        @precedence { simpleRepetitionOperator, identifier }
     @precedence { paceKeyword, identifier }
     @precedence { setKeyword, identifier }
     @precedence { authorKeyword, identifier }


### PR DESCRIPTION
Added the ability to model simplified repetitions in swimDSL

<img width="1188" height="283" alt="image" src="https://github.com/user-attachments/assets/1bcdf297-9967-4838-b6b9-1bddf80848af" />

Closes #12 